### PR TITLE
Add updateList Firestore tests

### DIFF
--- a/lib/db.test.ts
+++ b/lib/db.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { updateList } from './db'
+import type { Category } from '../types/categories'
+
+// In-memory mock store to simulate Firestore documents
+const store: Record<string, any> = {}
+
+// Mock Firestore functions
+const doc = vi.fn((_db: unknown, _collection: string, id: string) => ({ id }))
+const getDoc = vi.fn(async (ref: any) => ({
+  exists: () => !!store[ref.id],
+  data: () => store[ref.id]
+}))
+const setDoc = vi.fn(async (ref: any, data: any, options?: any) => {
+  if (options?.merge) {
+    store[ref.id] = { ...store[ref.id], ...data }
+  } else {
+    store[ref.id] = data
+  }
+})
+
+vi.mock('firebase/firestore', () => ({ doc, getDoc, setDoc }))
+vi.mock('./firebase', () => ({ db: {} }))
+vi.mock('firebase/app', () => ({
+  FirebaseError: class extends Error {
+    code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+}))
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+describe('updateList', () => {
+  const listId = 'list-1'
+  const createdAt = '2024-01-01T00:00:00.000Z'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-10T00:00:00.000Z'))
+    store[listId] = { categories: [], createdAt, updatedAt: '2024-01-02T00:00:00.000Z' }
+    doc.mockClear()
+    getDoc.mockClear()
+    setDoc.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('preserves the createdAt field when updating existing lists', async () => {
+    const now = new Date().toISOString()
+    const categories: Category[] = [
+      {
+        id: 1,
+        emoji: '🥬',
+        name: 'Veg',
+        items: [
+          { id: 1, name: 'Carrot', purchased: false }
+        ]
+      }
+    ]
+
+    await updateList(listId, categories)
+
+    expect(store[listId].createdAt).toBe(createdAt)
+    expect(store[listId].updatedAt).toBe(now)
+  })
+
+  it('stores sanitized category and item data correctly', async () => {
+    const now = new Date().toISOString()
+    const dirtyCategories: any = [
+      {
+        id: 1,
+        emoji: '🥬',
+        name: 'Veg',
+        extraField: 'remove',
+        items: [
+          { id: 1, name: 'Carrot', purchased: false, extra: 'x' },
+          { id: 2, name: 'Potato', purchased: true, comment: 'fresh', photo: 'url', unwanted: 'y' }
+        ]
+      }
+    ]
+
+    await updateList(listId, dirtyCategories)
+
+    const expected: Category[] = [
+      {
+        id: 1,
+        emoji: '🥬',
+        name: 'Veg',
+        items: [
+          { id: 1, name: 'Carrot', purchased: false, comment: '', photo: null },
+          { id: 2, name: 'Potato', purchased: true, comment: 'fresh', photo: 'url' }
+        ]
+      }
+    ]
+
+    expect(store[listId]).toEqual({ categories: expected, createdAt, updatedAt: now })
+  })
+})
+

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -100,10 +100,14 @@ export async function updateList(listId: string, categories: Category[]) {
       })
     } else {
       // Update existing list with only allowed fields
-      await setDoc(listRef, {
-        categories: sanitizedCategories,
-        updatedAt: timestamp
-      })
+      await setDoc(
+        listRef,
+        {
+          categories: sanitizedCategories,
+          updatedAt: timestamp
+        },
+        { merge: true }
+      )
     }
   } catch (error) {
     if (error instanceof FirebaseError) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -78,6 +79,7 @@
     "eslint-config-next": "15.1.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.3"
   }
 }


### PR DESCRIPTION
## Summary
- ensure updateList keeps createdAt when updating lists
- mock Firestore and test data sanitization

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68911baea5f88323b4ac7cd8741c443a