### PR TITLE
Add experimental purpose-based lists feature

### DIFF
--- a/components/AddItemForm.tsx
+++ b/components/AddItemForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useTabView } from '@/contexts/TabViewContext'
+import { TabView, useTabView } from '@/contexts/TabViewContext'
 import { Category } from '@/types/categories'
 import { motion } from 'framer-motion'
 import { Package, Plus, Sparkles, X } from 'lucide-react'
@@ -13,18 +13,20 @@ interface AddItemFormProps {
     itemName: string,
     itemComment: string,
     categorySelection: string,
-    activeTab: 'grocery' | 'pharmacy'
+    activeTab: TabView
   ) => void
   onClose: () => void
   categories: Category[]
 }
 
 export default function AddItemForm({ onAddBackground, onClose, categories }: AddItemFormProps) {
+  const { activeTab } = useTabView()
+  const isPurpose = activeTab === 'purpose'
   const [item, setItem] = useState('')
   const [comment, setComment] = useState('')
-  const [categoryId, setCategoryId] = useState('auto')
+  // Purpose lists have no AI categorization, so default to the first category.
+  const [categoryId, setCategoryId] = useState(() => (isPurpose ? (categories[0]?.id.toString() ?? '') : 'auto'))
   const inputRef = useRef<HTMLInputElement>(null)
-  const { activeTab } = useTabView()
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -67,14 +69,16 @@ export default function AddItemForm({ onAddBackground, onClose, categories }: Ad
 
     setItem('')
     setComment('')
-    setCategoryId('auto')
+    setCategoryId(isPurpose ? (categories[0]?.id.toString() ?? '') : 'auto')
     onClose()
     onAddBackground(itemName, itemComment, selectedCategory, activeTab)
   }
 
-  const filteredCategories = categories.filter(cat =>
-    activeTab === 'pharmacy' ? cat.name === 'בית מרקחת' : cat.name !== 'בית מרקחת'
-  )
+  const filteredCategories = isPurpose
+    ? categories
+    : categories.filter(cat =>
+        activeTab === 'pharmacy' ? cat.name === 'בית מרקחת' : cat.name !== 'בית מרקחת'
+      )
 
   return (
     <div className="relative text-right flex flex-col">
@@ -130,7 +134,7 @@ export default function AddItemForm({ onAddBackground, onClose, categories }: Ad
           onCategoryChange={setCategoryId}
           categories={filteredCategories}
           showCategorySelector={activeTab !== 'pharmacy'}
-          showSmartOption={true}
+          showSmartOption={!isPurpose}
         />
 
         {/* Submit Button */}

--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -220,8 +220,10 @@ const CategoryList = memo(function CategoryList({
           </motion.div>
         )
       ) : (
-        // Grocery view - original category-based layout
-        sortedCategories.some(category => category.items.length > 0) ? (
+        // Grocery / purpose view - category-based layout.
+        // Purpose lists show their (possibly empty) categories so items can be added;
+        // grocery only renders categories that already have items.
+        (activeTab === 'purpose' ? sortedCategories.length > 0 : sortedCategories.some(category => category.items.length > 0)) ? (
           sortedCategories.map((category) => {
             const uncheckedCount = category.items.filter(item => !item.purchased).length
             const totalCount = category.items.length
@@ -353,10 +355,12 @@ const CategoryList = memo(function CategoryList({
             animate={{ opacity: 1, y: 0 }}
             className="bg-white rounded-2xl overflow-hidden border border-black/5 shadow-sm p-8 text-center"
           >
-            <div className="text-4xl mb-4">🛍️</div>
+            <div className="text-4xl mb-4">{activeTab === 'purpose' ? '📝' : '🛍️'}</div>
             <h3 className="text-lg font-semibold text-black/80 mb-2">הרשימה ריקה</h3>
             <p className="text-sm text-black/60">
-              לחצו על הכפתור למטה כדי להוסיף פריטים לרשימה
+              {activeTab === 'purpose'
+                ? 'הוסיפו קטגוריה כדי להתחיל לבנות את הרשימה'
+                : 'לחצו על הכפתור למטה כדי להוסיף פריטים לרשימה'}
             </p>
           </motion.div>
         )

--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -2,7 +2,8 @@
 
 import { useSettings } from '@/contexts/SettingsContext'
 import { useTabView } from '@/contexts/TabViewContext'
-import { ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Search, X } from 'lucide-react'
+import { PurposeList } from '@/types/purpose-list'
+import { ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Plus, Search, X } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
@@ -13,6 +14,8 @@ interface CompactHeaderProps {
   searchQuery: string
   onSearchChange: (query: string) => void
   onOpenSettings: () => void
+  purposeLists: PurposeList[]
+  onCreatePurposeList: () => void
 }
 
 function CircularProgress({ percentage }: { percentage: number }) {
@@ -65,10 +68,10 @@ function CircularProgress({ percentage }: { percentage: number }) {
   )
 }
 
-export default function CompactHeader({ uncheckedItems, totalItems, searchQuery, onSearchChange, onOpenSettings }: CompactHeaderProps) {
+export default function CompactHeader({ uncheckedItems, totalItems, searchQuery, onSearchChange, onOpenSettings, purposeLists, onCreatePurposeList }: CompactHeaderProps) {
   const params = useParams()
   const listId = params?.listId as string
-  const { activeTab, setActiveTab } = useTabView()
+  const { activeTab, setActiveTab, activePurposeListId, selectPurposeList } = useTabView()
   const { flags } = useSettings()
 
   const completedItems = totalItems - uncheckedItems
@@ -117,10 +120,10 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
           </div>
 
           {/* Tab Pills */}
-          <div className="flex bg-gray-100 rounded-full p-1">
+          <div className="flex bg-gray-100 rounded-full p-1 overflow-x-auto max-w-[55%]">
             <button
               onClick={() => setActiveTab('grocery')}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+              className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
                 activeTab === 'grocery'
                   ? 'bg-[#FFB74D] text-white shadow-sm'
                   : 'text-gray-500 hover:text-gray-700'
@@ -131,7 +134,7 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
             </button>
             <button
               onClick={() => setActiveTab('pharmacy')}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+              className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
                 activeTab === 'pharmacy'
                   ? 'bg-[#FFB74D] text-white shadow-sm'
                   : 'text-gray-500 hover:text-gray-700'
@@ -143,7 +146,7 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
             {flags.enableRecipes && (
               <button
                 onClick={() => setActiveTab('recipes')}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+                className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
                   activeTab === 'recipes'
                     ? 'bg-[#FFB74D] text-white shadow-sm'
                     : 'text-gray-500 hover:text-gray-700'
@@ -151,6 +154,29 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
               >
                 <ChefHat className="w-4 h-4" />
                 <span className="hidden sm:inline">מתכונים</span>
+              </button>
+            )}
+            {flags.enablePurposeLists && purposeLists.map((list) => (
+              <button
+                key={list.id}
+                onClick={() => selectPurposeList(list.id)}
+                className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+                  activeTab === 'purpose' && activePurposeListId === list.id
+                    ? 'bg-[#FFB74D] text-white shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                <span>{list.emoji}</span>
+                <span className="hidden sm:inline max-w-[80px] truncate">{list.name}</span>
+              </button>
+            ))}
+            {flags.enablePurposeLists && (
+              <button
+                onClick={onCreatePurposeList}
+                className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-700 hover:bg-gray-200 transition-all duration-200"
+                title="רשימה חדשה"
+              >
+                <Plus className="w-4 h-4" />
               </button>
             )}
           </div>

--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -120,7 +120,7 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
           </div>
 
           {/* Tab Pills */}
-          <div className="flex bg-gray-100 rounded-full p-1 overflow-x-auto max-w-[55%]">
+          <div className="flex bg-gray-100 rounded-full p-1">
             <button
               onClick={() => setActiveTab('grocery')}
               className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
@@ -156,29 +156,6 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
                 <span className="hidden sm:inline">מתכונים</span>
               </button>
             )}
-            {flags.enablePurposeLists && purposeLists.map((list) => (
-              <button
-                key={list.id}
-                onClick={() => selectPurposeList(list.id)}
-                className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
-                  activeTab === 'purpose' && activePurposeListId === list.id
-                    ? 'bg-[#FFB74D] text-white shadow-sm'
-                    : 'text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                <span>{list.emoji}</span>
-                <span className="hidden sm:inline max-w-[80px] truncate">{list.name}</span>
-              </button>
-            ))}
-            {flags.enablePurposeLists && (
-              <button
-                onClick={onCreatePurposeList}
-                className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:text-gray-700 hover:bg-gray-200 transition-all duration-200"
-                title="רשימה חדשה"
-              >
-                <Plus className="w-4 h-4" />
-              </button>
-            )}
           </div>
 
           {/* Settings & Share buttons */}
@@ -200,6 +177,36 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
           </div>
         </div>
       </div>
+
+      {/* Purpose lists - dedicated full-width scrollable row */}
+      {flags.enablePurposeLists && (
+        <div className="max-w-2xl mx-auto px-4 pb-2">
+          <div className="flex items-center gap-2 overflow-x-auto pb-1 -mb-1">
+            {purposeLists.map((list) => (
+              <button
+                key={list.id}
+                onClick={() => selectPurposeList(list.id)}
+                className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all duration-200 ${
+                  activeTab === 'purpose' && activePurposeListId === list.id
+                    ? 'bg-[#FFB74D] text-white border-[#FFB74D] shadow-sm'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-[#FFB74D]/50 hover:text-gray-800'
+                }`}
+              >
+                <span>{list.emoji}</span>
+                <span className="max-w-[140px] truncate">{list.name}</span>
+              </button>
+            ))}
+            <button
+              onClick={onCreatePurposeList}
+              className="flex-shrink-0 flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium text-[#FFB74D] border border-dashed border-[#FFB74D]/50 hover:bg-[#FFB74D]/5 transition-all duration-200"
+              title="רשימה חדשה"
+            >
+              <Plus className="w-4 h-4" />
+              <span>רשימה</span>
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Search Box */}
       <div className="max-w-2xl mx-auto px-4 pb-3">

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -23,8 +23,6 @@ const SettingsPanel = dynamic(() => import('./SettingsPanel'))
 const RecipesTab = dynamic(() => import('./RecipesTab'))
 const NameEmojiModal = dynamic(() => import('./NameEmojiModal'))
 
-const PURPOSE_CATEGORY_PALETTE = ['📦', '👕', '👟', '🧴', '📄', '🔌', '🍴', '💊', '🎮', '📚', '🧸', '🏷️']
-
 // Lazy load modal components to reduce initial bundle size
 const AddItemForm = dynamic(() => import('./AddItemForm'), {
   loading: () => <div className="text-center py-8">טוען...</div>
@@ -1189,7 +1187,7 @@ export default function HomeScreen() {
                   title="קטגוריה חדשה"
                   submitLabel="הוסף קטגוריה"
                   namePlaceholder="שם הקטגוריה"
-                  emojiPalette={PURPOSE_CATEGORY_PALETTE}
+                  initialEmoji="📦"
                   onSubmit={handleAddPurposeCategory}
                   onClose={() => setIsAddCategoryOpen(false)}
                 />

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import { useSettings } from '@/contexts/SettingsContext'
-import { useTabView } from '@/contexts/TabViewContext'
+import { TabView, useTabView } from '@/contexts/TabViewContext'
 import { subscribeToList, updateList } from '@/lib/db'
 import { OpenRouter } from '@/lib/openrouter'
 import { computeRepeatSuggestions, updateItemPurchaseStats } from '@/lib/repeat-suggester'
 import { Category, initialCategories } from '@/types/categories'
 import { Item } from '@/types/item'
+import { PurposeList } from '@/types/purpose-list'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Loader2, Plus, Sparkles } from 'lucide-react'
+import { Loader2, Pencil, Plus, Sparkles } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useParams } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -20,6 +21,9 @@ import RepeatSuggestions from './RepeatSuggestions'
 
 const SettingsPanel = dynamic(() => import('./SettingsPanel'))
 const RecipesTab = dynamic(() => import('./RecipesTab'))
+const NameEmojiModal = dynamic(() => import('./NameEmojiModal'))
+
+const PURPOSE_CATEGORY_PALETTE = ['📦', '👕', '👟', '🧴', '📄', '🔌', '🍴', '💊', '🎮', '📚', '🧸', '🏷️']
 
 // Lazy load modal components to reduce initial bundle size
 const AddItemForm = dynamic(() => import('./AddItemForm'), {
@@ -38,6 +42,7 @@ const normalizeCategory = (name: string): string =>
 
 export default function HomeScreen() {
   const [categories, setCategories] = useState<Category[]>(initialCategories)
+  const [purposeLists, setPurposeLists] = useState<PurposeList[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isAddFormOpen, setIsAddFormOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -50,8 +55,47 @@ export default function HomeScreen() {
   const [pendingScrollItemId, setPendingScrollItemId] = useState<number | null>(null)
   const [pendingAddCount, setPendingAddCount] = useState(0)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const { activeTab } = useTabView()
+  // Purpose list modal: 'create' for a new list, or an existing list for edit/delete
+  const [purposeModal, setPurposeModal] = useState<{ mode: 'create' } | { mode: 'edit'; list: PurposeList } | null>(null)
+  const [isAddCategoryOpen, setIsAddCategoryOpen] = useState(false)
+  const { activeTab, setActiveTab, activePurposeListId, selectPurposeList } = useTabView()
   const { flags } = useSettings()
+
+  // When a purpose list tab is active, all reads/writes target that list's
+  // categories instead of the main grocery/pharmacy categories.
+  const activePurposeList = useMemo(
+    () => (activeTab === 'purpose' ? purposeLists.find(p => p.id === activePurposeListId) ?? null : null),
+    [activeTab, activePurposeListId, purposeLists]
+  )
+  const isPurposeMode = activePurposeList !== null
+  const currentCategories = isPurposeMode ? activePurposeList!.categories : categories
+
+  // Single commit point: routes the updated categories to either the main list
+  // or the active purpose list, persists the whole document, and reverts on error.
+  const commitCategories = async (nextCategories: Category[]) => {
+    if (isPurposeMode && activePurposeList) {
+      const previous = purposeLists
+      const nextPurposeLists = purposeLists.map(p =>
+        p.id === activePurposeList.id ? { ...p, categories: nextCategories } : p
+      )
+      setPurposeLists(nextPurposeLists)
+      try {
+        await updateList(listId, categories, nextPurposeLists)
+      } catch (error) {
+        console.error('Error updating list:', error)
+        setPurposeLists(previous)
+      }
+    } else {
+      const previous = categories
+      setCategories(nextCategories)
+      try {
+        await updateList(listId, nextCategories, purposeLists)
+      } catch (error) {
+        console.error('Error updating list:', error)
+        setCategories(previous)
+      }
+    }
+  }
 
   // Filter items based on search query
   const getSearchResults = () => {
@@ -63,15 +107,15 @@ export default function HomeScreen() {
       categoryId: number
     }> = []
     
-    categories.forEach(category => {
-      // Filter categories based on active tab
+    currentCategories.forEach(category => {
+      // Filter categories based on active tab (no-op in purpose mode)
       if (activeTab === 'grocery' && category.name === 'בית מרקחת') {
         return // Skip pharmacy category when in grocery mode
       }
       if (activeTab === 'pharmacy' && category.name !== 'בית מרקחת') {
         return // Skip non-pharmacy categories when in pharmacy mode
       }
-      
+
       category.items.forEach(item => {
         if (item.name.toLowerCase().includes(searchQuery.toLowerCase())) {
           results.push({ item, category, categoryId: category.id })
@@ -101,6 +145,9 @@ export default function HomeScreen() {
   }, {} as Record<number, { category: Category; items: Item[] }>)
 
   const repeatSuggestions = useMemo(() => {
+    // Repeat suggestions are grocery/pharmacy-only (EWMA purchase prediction).
+    if (isPurposeMode) return []
+
     const relevantCategories = categories.filter(category => {
       if (activeTab === 'grocery') return category.name !== 'בית מרקחת'
       if (activeTab === 'pharmacy') return category.name === 'בית מרקחת'
@@ -108,7 +155,7 @@ export default function HomeScreen() {
     })
 
     return computeRepeatSuggestions(relevantCategories)
-  }, [categories, activeTab])
+  }, [categories, activeTab, isPurposeMode])
 
   // Helper function to highlight matching text
   const highlightText = (text: string, query: string) => {
@@ -153,11 +200,11 @@ export default function HomeScreen() {
     };
 
     // Find existing category first
-    let updatedCategories = [...categories];
+    let updatedCategories = [...currentCategories];
     let categoryId: number;
 
     const normalizedInput = normalizeCategory(categoryName);
-    const existingCategory = categories.find(c =>
+    const existingCategory = currentCategories.find(c =>
       normalizeCategory(c.name) === normalizedInput
     );
 
@@ -166,7 +213,7 @@ export default function HomeScreen() {
       categoryId = existingCategory.id;
     } else {
       // Create new category only if it doesn't exist
-      const maxId = Math.max(...categories.map(cat => cat.id), 0);
+      const maxId = Math.max(...currentCategories.map(cat => cat.id), 0);
       const newCategory = {
         id: maxId + 1,
         emoji: emoji,
@@ -189,17 +236,11 @@ export default function HomeScreen() {
       return category;
     });
 
-    try {
-      setCategories(updatedCategories);
-      setExpandedCategories((prev) => (
-        prev.includes(categoryId) ? prev : [...prev, categoryId]
-      ))
-      setPendingScrollItemId(newItem.id)
-      await updateList(listId, updatedCategories);
-    } catch (error) {
-      console.error('Error updating list:', error);
-      setCategories(categories);
-    }
+    setExpandedCategories((prev) => (
+      prev.includes(categoryId) ? prev : [...prev, categoryId]
+    ))
+    setPendingScrollItemId(newItem.id)
+    await commitCategories(updatedCategories);
   };
 
   // Handle adding item with background categorization (closes form immediately)
@@ -207,7 +248,7 @@ export default function HomeScreen() {
     itemName: string,
     itemComment: string,
     categorySelection: string,
-    currentActiveTab: 'grocery' | 'pharmacy'
+    currentActiveTab: TabView
   ) => {
     // Check for duplicates first
     if (checkDuplicateItem(itemName, itemComment)) {
@@ -227,7 +268,13 @@ export default function HomeScreen() {
       let category: string;
       let emoji: string;
 
-      if (currentActiveTab === 'pharmacy') {
+      if (isPurposeMode) {
+        // Purpose lists use manual category selection only (no AI categorization)
+        const selectedCategory = currentCategories.find(c => c.id.toString() === categorySelection);
+        if (!selectedCategory) throw new Error('Category not found');
+        category = selectedCategory.name;
+        emoji = selectedCategory.emoji;
+      } else if (currentActiveTab === 'pharmacy') {
         // For pharmacy mode, always use pharmacy category without smart categorization
         category = 'בית מרקחת';
         emoji = '💊';
@@ -269,7 +316,7 @@ export default function HomeScreen() {
     }
 
     const now = new Date()
-    const updatedCategories = categories.map(category => {
+    const updatedCategories = currentCategories.map(category => {
       if (category.id !== categoryId) return category
 
       const updatedItems = category.items
@@ -286,7 +333,8 @@ export default function HomeScreen() {
             }
           }
 
-          return updateItemPurchaseStats(item, now)
+          // Purpose items don't track purchase stats (no repeat suggestions)
+          return isPurposeMode ? { ...item, purchased: true } : updateItemPurchaseStats(item, now)
         })
         .sort((a, b) => (a.purchased === b.purchased ? 0 : a.purchased ? 1 : -1))
 
@@ -296,16 +344,7 @@ export default function HomeScreen() {
       }
     })
 
-    setCategories(updatedCategories)
-
-    if (listId) {
-      try {
-        await updateList(listId, updatedCategories)
-      } catch (error) {
-        console.error('Error updating list:', error)
-        setCategories(categories)
-      }
-    }
+    await commitCategories(updatedCategories)
   }
 
   const handleSnoozeItem = async (categoryId: number, itemId: number, days: number) => {
@@ -313,7 +352,7 @@ export default function HomeScreen() {
 
     const snoozeUntil = new Date(Date.now() + days * MS_PER_DAY).toISOString()
 
-    const updatedCategories = categories.map(category => {
+    const updatedCategories = currentCategories.map(category => {
       if (category.id !== categoryId) return category
 
       return {
@@ -329,39 +368,21 @@ export default function HomeScreen() {
       }
     })
 
-    setCategories(updatedCategories)
-
-    if (listId) {
-      try {
-        await updateList(listId, updatedCategories)
-      } catch (error) {
-        console.error('Error updating list:', error)
-        setCategories(categories)
-      }
-    }
+    await commitCategories(updatedCategories)
   }
 
   const handleDeleteItem = async (categoryId: number, itemId: number) => {
-    const updatedCategories = categories.map(category =>
+    const updatedCategories = currentCategories.map(category =>
       category.id === categoryId
         ? { ...category, items: category.items.filter(item => item.id !== itemId) }
         : category
     )
 
-    setCategories(updatedCategories)
-    
-    if (listId) {
-      try {
-        await updateList(listId, updatedCategories)
-      } catch (error) {
-        console.error('Error updating list:', error)
-        setCategories(categories)
-      }
-    }
+    await commitCategories(updatedCategories)
   }
 
   const handleAddItem = async (categoryId: number, name: string) => {
-    const category = categories.find(c => c.id === categoryId);
+    const category = currentCategories.find(c => c.id === categoryId);
     if (!category) return;
 
     const newItem: Item = {
@@ -378,7 +399,7 @@ export default function HomeScreen() {
       snoozeUntil: null,
     };
 
-    const updatedCategories = categories.map(c => {
+    const updatedCategories = currentCategories.map(c => {
       if (c.id === categoryId) {
         return {
           ...c,
@@ -388,36 +409,27 @@ export default function HomeScreen() {
       return c;
     });
 
-    setCategories(updatedCategories);
     setExpandedCategories((prev) => (
       prev.includes(categoryId) ? prev : [...prev, categoryId]
     ))
     setPendingScrollItemId(newItem.id)
-    
-    if (listId) {
-      try {
-        await updateList(listId, updatedCategories);
-      } catch (error) {
-        console.error('Error updating list:', error);
-        setCategories(categories); // Revert on error
-      }
-    }
+    await commitCategories(updatedCategories);
   };
 
   // Check if an item with the same name and description already exists in the current tab
   const checkDuplicateItem = (name: string, comment: string = '') => {
     const trimmedName = name.trim().toLowerCase();
     const trimmedComment = comment.trim().toLowerCase();
-    
-    for (const category of categories) {
-      // Only check categories relevant to the current tab
+
+    for (const category of currentCategories) {
+      // Only check categories relevant to the current tab (no-op in purpose mode)
       if (activeTab === 'grocery' && category.name === 'בית מרקחת') {
         continue; // Skip pharmacy category when in grocery mode
       }
       if (activeTab === 'pharmacy' && category.name !== 'בית מרקחת') {
         continue; // Skip non-pharmacy categories when in pharmacy mode
       }
-      
+
       for (const item of category.items) {
         if (item.name.trim().toLowerCase() === trimmedName && 
             (item.comment || '').trim().toLowerCase() === trimmedComment) {
@@ -431,6 +443,8 @@ export default function HomeScreen() {
   // Handle Quick Add from search results
   const handleQuickAddItem = async () => {
     if (!searchQuery.trim()) return;
+    // AI quick-add is grocery/pharmacy-only; purpose lists add items manually.
+    if (isPurposeMode) return;
 
     const itemName = searchQuery.trim();
 
@@ -505,7 +519,7 @@ export default function HomeScreen() {
       let itemToUpdate: Item | null = null;
       let sourceCategory: number | null = null;
 
-      for (const category of categories) {
+      for (const category of currentCategories) {
         const foundItem = category.items.find(item => item.id === itemId);
         if (foundItem) {
           itemToUpdate = foundItem;
@@ -531,11 +545,11 @@ export default function HomeScreen() {
 
       if (sourceCategory === newCategoryId) {
         // Same category - just update the item
-        updatedCategories = categories.map(category => {
+        updatedCategories = currentCategories.map(category => {
           if (category.id === sourceCategory) {
             return {
               ...category,
-              items: category.items.map(item => 
+              items: category.items.map(item =>
                 item.id === itemId ? updatedItem : item
               )
             };
@@ -544,7 +558,7 @@ export default function HomeScreen() {
         });
       } else {
         // Different category - move the item
-        updatedCategories = categories.map(category => {
+        updatedCategories = currentCategories.map(category => {
           if (category.id === sourceCategory) {
             // Remove from source category
             return {
@@ -562,8 +576,7 @@ export default function HomeScreen() {
         });
       }
 
-      setCategories(updatedCategories);
-      await updateList(listId, updatedCategories);
+      await commitCategories(updatedCategories);
       toast.success('הפריט עודכן בהצלחה');
     } catch (error) {
       console.error('Error updating item:', error);
@@ -658,7 +671,7 @@ export default function HomeScreen() {
       try {
         setCategories(updatedCategories)
         setExpandedCategories(prev => [...new Set([...prev, ...expandIds])])
-        await updateList(listId, updatedCategories)
+        await updateList(listId, updatedCategories, purposeLists)
         toast.success(`נוספו ${addedCount} מצרכים לרשימה`)
       } catch (error) {
         console.error('Error updating list:', error)
@@ -674,24 +687,20 @@ export default function HomeScreen() {
     setEditingItemCategoryId(categoryId);
   };
 
-  const uncheckedItems = categories
-    .filter(category => {
-      if (activeTab === 'grocery') return category.name !== 'בית מרקחת'
-      if (activeTab === 'pharmacy') return category.name === 'בית מרקחת'
-      return true
-    })
-    .reduce((total, category) => 
-      total + category.items.filter(item => !item.purchased).length, 0
-    )
-  const totalItems = categories
-    .filter(category => {
-      if (activeTab === 'grocery') return category.name !== 'בית מרקחת'
-      if (activeTab === 'pharmacy') return category.name === 'בית מרקחת'
-      return true
-    })
-    .reduce((total, category) => 
-      total + category.items.length, 0
-    )
+  // The categories that contribute to the progress ring for the active tab.
+  const visibleCategories = isPurposeMode
+    ? currentCategories
+    : categories.filter(category => {
+        if (activeTab === 'grocery') return category.name !== 'בית מרקחת'
+        if (activeTab === 'pharmacy') return category.name === 'בית מרקחת'
+        return true
+      })
+  const uncheckedItems = visibleCategories.reduce(
+    (total, category) => total + category.items.filter(item => !item.purchased).length, 0
+  )
+  const totalItems = visibleCategories.reduce(
+    (total, category) => total + category.items.length, 0
+  )
 
   useEffect(() => {
     setIsLoading(true)
@@ -700,6 +709,7 @@ export default function HomeScreen() {
       listId,
       data => {
         setCategories(data.categories)
+        setPurposeLists(data.purposeLists ?? [])
         setIsLoading(false)
       },
       error => {
@@ -712,6 +722,71 @@ export default function HomeScreen() {
       unsubscribe()
     }
   }, [listId])
+
+  // If the active purpose list disappears (deleted locally or by another client),
+  // fall back to the grocery tab.
+  useEffect(() => {
+    if (activeTab === 'purpose' && activePurposeListId && !purposeLists.some(p => p.id === activePurposeListId)) {
+      setActiveTab('grocery')
+    }
+  }, [purposeLists, activePurposeListId, activeTab, setActiveTab])
+
+  // Purpose list CRUD
+  const handleCreatePurposeList = async (name: string, emoji: string) => {
+    const newList: PurposeList = {
+      id: crypto.randomUUID(),
+      name,
+      emoji,
+      categories: [],
+      createdAt: new Date().toISOString(),
+    }
+    const next = [...purposeLists, newList]
+    setPurposeModal(null)
+    setPurposeLists(next)
+    selectPurposeList(newList.id)
+    try {
+      await updateList(listId, categories, next)
+    } catch (error) {
+      console.error('Error creating purpose list:', error)
+      setPurposeLists(purposeLists)
+    }
+  }
+
+  const handleUpdatePurposeList = async (id: string, name: string, emoji: string) => {
+    const previous = purposeLists
+    const next = purposeLists.map(p => (p.id === id ? { ...p, name, emoji } : p))
+    setPurposeModal(null)
+    setPurposeLists(next)
+    try {
+      await updateList(listId, categories, next)
+    } catch (error) {
+      console.error('Error updating purpose list:', error)
+      setPurposeLists(previous)
+    }
+  }
+
+  const handleDeletePurposeList = async (id: string) => {
+    const previous = purposeLists
+    const next = purposeLists.filter(p => p.id !== id)
+    setPurposeModal(null)
+    setPurposeLists(next)
+    setActiveTab('grocery')
+    try {
+      await updateList(listId, categories, next)
+    } catch (error) {
+      console.error('Error deleting purpose list:', error)
+      setPurposeLists(previous)
+    }
+  }
+
+  // Add a new (manually named) category to the active purpose list
+  const handleAddPurposeCategory = (name: string, emoji: string) => {
+    const maxId = Math.max(0, ...currentCategories.map(c => c.id))
+    const newCategory: Category = { id: maxId + 1, name, emoji, items: [] }
+    setIsAddCategoryOpen(false)
+    setExpandedCategories(prev => [...prev, newCategory.id])
+    commitCategories([...currentCategories, newCategory])
+  }
 
   useEffect(() => {
     if (isAddFormOpen) {
@@ -787,6 +862,8 @@ export default function HomeScreen() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         onOpenSettings={() => setIsSettingsOpen(true)}
+        purposeLists={purposeLists}
+        onCreatePurposeList={() => setPurposeModal({ mode: 'create' })}
       />
       <AnimatePresence>
         {isSettingsOpen && (
@@ -827,7 +904,7 @@ export default function HomeScreen() {
         {/* Search Results */}
         {activeTab !== 'recipes' && isSearchMode && (
           <div className="space-y-4 mb-6">
-            {searchResults.length > 0 && !hasExactMatch && (
+            {searchResults.length > 0 && !hasExactMatch && !isPurposeMode && (
               <motion.button
                 onClick={handleQuickAddItem}
                 disabled={pendingAddCount > 0}
@@ -905,6 +982,16 @@ export default function HomeScreen() {
                   </div>
                 </div>
               ))
+            ) : isPurposeMode ? (
+              <div className="bg-white rounded-2xl border border-black/5 shadow-sm p-8 text-center">
+                <div className="text-4xl mb-4">🔍</div>
+                <h3 className="text-lg font-semibold text-black/80 mb-2">
+                  לא מצאנו את &ldquo;{searchQuery}&rdquo;
+                </h3>
+                <p className="text-sm text-black/60">
+                  נקו את החיפוש כדי להוסיף פריטים לקטגוריות הרשימה
+                </p>
+              </div>
             ) : (
               <EmptySearchState
                 searchQuery={searchQuery}
@@ -929,10 +1016,27 @@ export default function HomeScreen() {
           </div>
         )}
 
+        {/* Purpose list header with rename/delete */}
+        {isPurposeMode && !isSearchMode && activePurposeList && (
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-2xl">{activePurposeList.emoji}</span>
+              <h2 className="text-lg font-bold text-black/80 truncate">{activePurposeList.name}</h2>
+            </div>
+            <button
+              onClick={() => setPurposeModal({ mode: 'edit', list: activePurposeList })}
+              className="flex-shrink-0 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-all duration-200"
+              title="עריכת רשימה"
+            >
+              <Pencil className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
         {/* Category List - Only show when not in search mode and not on recipes tab */}
         {activeTab !== 'recipes' && !isSearchMode && (
           <CategoryList
-            categories={categories.filter(category => category.items.length > 0)}
+            categories={isPurposeMode ? currentCategories : categories.filter(category => category.items.length > 0)}
             onToggleItem={handleToggleItem}
             onDeleteItem={handleDeleteItem}
             expandedCategories={expandedCategories}
@@ -941,6 +1045,17 @@ export default function HomeScreen() {
             onAddItem={handleAddItem}
             isSearchMode={isSearchMode}
           />
+        )}
+
+        {/* Add category button for purpose lists */}
+        {isPurposeMode && !isSearchMode && (
+          <button
+            onClick={() => setIsAddCategoryOpen(true)}
+            className="mt-4 w-full flex items-center justify-center gap-2 py-3 rounded-2xl border-2 border-dashed border-[#FFB74D]/40 text-[#FFB74D] hover:bg-[#FFB74D]/5 transition-colors text-sm font-medium"
+          >
+            <Plus className="w-4 h-4" />
+            <span>הוסף קטגוריה</span>
+          </button>
         )}
 
         <AnimatePresence>
@@ -967,7 +1082,7 @@ export default function HomeScreen() {
                   <AddItemForm
                     onAddBackground={handleAddItemBackground}
                     onClose={() => setIsAddFormOpen(false)}
-                    categories={categories}
+                    categories={currentCategories}
                   />
                 </div>
               </motion.div>
@@ -1002,7 +1117,7 @@ export default function HomeScreen() {
                   <EditItemModal
                     item={editingItem}
                     currentCategoryId={editingItemCategoryId}
-                    categories={categories}
+                    categories={currentCategories}
                     onSave={handleUpdateItem}
                     onClose={() => {
                       setEditingItem(null);
@@ -1010,6 +1125,74 @@ export default function HomeScreen() {
                     }}
                   />
                 </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+
+        {/* Create / edit purpose list modal */}
+        <AnimatePresence>
+          {purposeModal && (
+            <>
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                onClick={() => setPurposeModal(null)}
+                className="fixed inset-0 bg-black/50 z-50"
+              />
+              <motion.div
+                initial={{ opacity: 0, scale: 0.95, y: -20 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.95, y: -20 }}
+                transition={{ type: 'spring', damping: 25, stiffness: 350 }}
+                className="fixed inset-x-4 top-[12vh] z-50 max-w-md mx-auto"
+              >
+                <NameEmojiModal
+                  title={purposeModal.mode === 'create' ? 'רשימה חדשה' : 'עריכת רשימה'}
+                  submitLabel={purposeModal.mode === 'create' ? 'צור רשימה' : 'שמור'}
+                  namePlaceholder="שם הרשימה (לדוגמה: טיול לאיטליה)"
+                  initialName={purposeModal.mode === 'edit' ? purposeModal.list.name : ''}
+                  initialEmoji={purposeModal.mode === 'edit' ? purposeModal.list.emoji : undefined}
+                  onSubmit={(name, emoji) =>
+                    purposeModal.mode === 'create'
+                      ? handleCreatePurposeList(name, emoji)
+                      : handleUpdatePurposeList(purposeModal.list.id, name, emoji)
+                  }
+                  onClose={() => setPurposeModal(null)}
+                  onDelete={purposeModal.mode === 'edit' ? () => handleDeletePurposeList(purposeModal.list.id) : undefined}
+                />
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+
+        {/* Add category to purpose list modal */}
+        <AnimatePresence>
+          {isAddCategoryOpen && (
+            <>
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                onClick={() => setIsAddCategoryOpen(false)}
+                className="fixed inset-0 bg-black/50 z-50"
+              />
+              <motion.div
+                initial={{ opacity: 0, scale: 0.95, y: -20 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.95, y: -20 }}
+                transition={{ type: 'spring', damping: 25, stiffness: 350 }}
+                className="fixed inset-x-4 top-[12vh] z-50 max-w-md mx-auto"
+              >
+                <NameEmojiModal
+                  title="קטגוריה חדשה"
+                  submitLabel="הוסף קטגוריה"
+                  namePlaceholder="שם הקטגוריה"
+                  emojiPalette={PURPOSE_CATEGORY_PALETTE}
+                  onSubmit={handleAddPurposeCategory}
+                  onClose={() => setIsAddCategoryOpen(false)}
+                />
               </motion.div>
             </>
           )}
@@ -1042,7 +1225,14 @@ export default function HomeScreen() {
             className="fixed bottom-6 right-6 z-30"
           >
             <button
-              onClick={() => setIsAddFormOpen(prev => !prev)}
+              onClick={() => {
+                // A blank purpose list has no categories yet — guide to create one first
+                if (isPurposeMode && currentCategories.length === 0) {
+                  setIsAddCategoryOpen(true)
+                } else {
+                  setIsAddFormOpen(prev => !prev)
+                }
+              }}
               className="bg-[#FFB74D] hover:bg-[#FFA726] text-white p-4 rounded-full hover:shadow-md transition-all duration-200"
             >
               <Plus className="h-6 w-6" />

--- a/components/NameEmojiModal.tsx
+++ b/components/NameEmojiModal.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Trash2, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+interface NameEmojiModalProps {
+  title: string
+  submitLabel: string
+  namePlaceholder?: string
+  initialName?: string
+  initialEmoji?: string
+  emojiPalette?: string[]
+  onSubmit: (name: string, emoji: string) => void
+  onClose: () => void
+  // When provided, renders a delete button (edit mode).
+  onDelete?: () => void
+}
+
+const DEFAULT_PALETTE = ['🎉', '🧳', '🏖️', '🎂', '🎄', '🏕️', '🎁', '🛠️', '🏠', '🐶', '👶', '📦']
+
+export default function NameEmojiModal({
+  title,
+  submitLabel,
+  namePlaceholder = 'שם',
+  initialName = '',
+  initialEmoji,
+  emojiPalette = DEFAULT_PALETTE,
+  onSubmit,
+  onClose,
+  onDelete,
+}: NameEmojiModalProps) {
+  const [name, setName] = useState(initialName)
+  const [emoji, setEmoji] = useState(initialEmoji || emojiPalette[0])
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const timer = setTimeout(() => inputRef.current?.focus(), 100)
+    return () => clearTimeout(timer)
+  }, [])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onSubmit(trimmed, emoji.trim() || emojiPalette[0])
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      transition={{ type: 'spring', damping: 25, stiffness: 350 }}
+      className="bg-white rounded-2xl shadow-2xl border border-black/5 overflow-hidden text-right"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-black/5">
+        <h2 className="text-base font-bold text-black/80">{title}</h2>
+        <button
+          onClick={onClose}
+          className="p-1.5 hover:bg-gray-100 rounded-full transition-colors"
+        >
+          <X className="h-4 w-4 text-black/40" />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="p-4 space-y-4">
+        {/* Name + selected emoji */}
+        <div className="flex gap-2 items-center">
+          <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-gray-50 border border-gray-200 flex items-center justify-center text-xl">
+            {emoji}
+          </div>
+          <input
+            ref={inputRef}
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={namePlaceholder}
+            className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-3 py-2.5 text-right text-sm focus:outline-none focus:ring-2 focus:ring-[#FFB74D]/50 focus:border-[#FFB74D]"
+            required
+          />
+        </div>
+
+        {/* Emoji palette */}
+        <div className="flex flex-wrap gap-2">
+          {emojiPalette.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setEmoji(option)}
+              className={`w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-colors ${
+                emoji === option ? 'bg-[#FFB74D]/20 ring-2 ring-[#FFB74D]' : 'bg-gray-50 hover:bg-gray-100'
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+          <input
+            type="text"
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            aria-label="אימוג'י מותאם"
+            className="w-12 h-9 rounded-lg bg-gray-50 border border-gray-200 text-center text-lg focus:outline-none focus:ring-2 focus:ring-[#FFB74D]/50"
+            maxLength={4}
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={!name.trim()}
+            className="flex-1 bg-gradient-to-r from-[#FFB74D] to-[#FFA726] text-white font-semibold py-2.5 px-4 rounded-xl shadow-md shadow-orange-200/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+          >
+            {submitLabel}
+          </button>
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="flex-shrink-0 p-2.5 rounded-xl bg-red-50 text-red-500 hover:bg-red-100 transition-colors"
+              title="מחיקה"
+            >
+              <Trash2 className="h-5 w-5" />
+            </button>
+          )}
+        </div>
+      </form>
+    </motion.div>
+  )
+}

--- a/components/NameEmojiModal.tsx
+++ b/components/NameEmojiModal.tsx
@@ -2,7 +2,14 @@
 
 import { motion } from 'framer-motion'
 import { Trash2, X } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
+
+// The full emoji picker (search + all emojis). Loaded on demand, client-only.
+const EmojiPicker = dynamic(() => import('emoji-picker-react'), {
+  ssr: false,
+  loading: () => <div className="p-4 text-center text-sm text-black/40">טוען אימוג&apos;ים...</div>,
+})
 
 interface NameEmojiModalProps {
   title: string
@@ -10,28 +17,25 @@ interface NameEmojiModalProps {
   namePlaceholder?: string
   initialName?: string
   initialEmoji?: string
-  emojiPalette?: string[]
   onSubmit: (name: string, emoji: string) => void
   onClose: () => void
   // When provided, renders a delete button (edit mode).
   onDelete?: () => void
 }
 
-const DEFAULT_PALETTE = ['🎉', '🧳', '🏖️', '🎂', '🎄', '🏕️', '🎁', '🛠️', '🏠', '🐶', '👶', '📦']
-
 export default function NameEmojiModal({
   title,
   submitLabel,
   namePlaceholder = 'שם',
   initialName = '',
-  initialEmoji,
-  emojiPalette = DEFAULT_PALETTE,
+  initialEmoji = '🎉',
   onSubmit,
   onClose,
   onDelete,
 }: NameEmojiModalProps) {
   const [name, setName] = useState(initialName)
-  const [emoji, setEmoji] = useState(initialEmoji || emojiPalette[0])
+  const [emoji, setEmoji] = useState(initialEmoji)
+  const [showPicker, setShowPicker] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -43,7 +47,7 @@ export default function NameEmojiModal({
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) return
-    onSubmit(trimmed, emoji.trim() || emojiPalette[0])
+    onSubmit(trimmed, emoji || initialEmoji)
   }
 
   return (
@@ -65,12 +69,19 @@ export default function NameEmojiModal({
         </button>
       </div>
 
-      <form onSubmit={handleSubmit} className="p-4 space-y-4">
-        {/* Name + selected emoji */}
+      <form onSubmit={handleSubmit} className="p-4 space-y-3">
+        {/* Name + emoji trigger */}
         <div className="flex gap-2 items-center">
-          <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-gray-50 border border-gray-200 flex items-center justify-center text-xl">
+          <button
+            type="button"
+            onClick={() => setShowPicker(v => !v)}
+            aria-label="בחירת אימוג'י"
+            className={`flex-shrink-0 w-11 h-11 rounded-xl bg-gray-50 border flex items-center justify-center text-xl transition-colors ${
+              showPicker ? 'border-[#FFB74D] ring-2 ring-[#FFB74D]/40' : 'border-gray-200 hover:bg-gray-100'
+            }`}
+          >
             {emoji}
-          </div>
+          </button>
           <input
             ref={inputRef}
             type="text"
@@ -82,29 +93,23 @@ export default function NameEmojiModal({
           />
         </div>
 
-        {/* Emoji palette */}
-        <div className="flex flex-wrap gap-2">
-          {emojiPalette.map((option) => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => setEmoji(option)}
-              className={`w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-colors ${
-                emoji === option ? 'bg-[#FFB74D]/20 ring-2 ring-[#FFB74D]' : 'bg-gray-50 hover:bg-gray-100'
-              }`}
-            >
-              {option}
-            </button>
-          ))}
-          <input
-            type="text"
-            value={emoji}
-            onChange={(e) => setEmoji(e.target.value)}
-            aria-label="אימוג'י מותאם"
-            className="w-12 h-9 rounded-lg bg-gray-50 border border-gray-200 text-center text-lg focus:outline-none focus:ring-2 focus:ring-[#FFB74D]/50"
-            maxLength={4}
-          />
-        </div>
+        {/* Full emoji picker (toggled) */}
+        {showPicker && (
+          <div className="flex justify-center" dir="ltr">
+            <EmojiPicker
+              onEmojiClick={(data: { emoji: string }) => {
+                setEmoji(data.emoji)
+                setShowPicker(false)
+                inputRef.current?.focus()
+              }}
+              width="100%"
+              height={320}
+              previewConfig={{ showPreview: false }}
+              searchPlaceHolder="חיפוש"
+              lazyLoadEmojis
+            />
+          </div>
+        )}
 
         {/* Actions */}
         <div className="flex items-center gap-2 pt-1">

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useSettings } from '@/contexts/SettingsContext'
 import { motion } from 'framer-motion'
-import { ChefHat, Star, X } from 'lucide-react'
+import { ChefHat, ListChecks, Star, X } from 'lucide-react'
 
 interface SettingsPanelProps {
   onClose: () => void
@@ -85,6 +85,14 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           description="סמן פריטים שנקנים הכי הרבה ומיין לפיהם בכל קטגוריה"
           enabled={flags.enableMostPurchased}
           onToggle={(v) => setFlag('enableMostPurchased', v)}
+        />
+
+        <FeatureToggle
+          icon={<ListChecks className="h-5 w-5" />}
+          title="רשימות ייעודיות"
+          description="צרו רשימות לאירוע, חופשה או מטרה מיוחדת לצד רשימת הקניות"
+          enabled={flags.enablePurposeLists}
+          onToggle={(v) => setFlag('enablePurposeLists', v)}
         />
       </div>
     </motion.div>

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -5,11 +5,13 @@ import { createContext, ReactNode, useCallback, useContext, useEffect, useState 
 interface FeatureFlags {
   enableRecipes: boolean
   enableMostPurchased: boolean
+  enablePurposeLists: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   enableRecipes: false,
   enableMostPurchased: false,
+  enablePurposeLists: false,
 }
 
 interface SettingsContextType {

--- a/contexts/TabViewContext.tsx
+++ b/contexts/TabViewContext.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { createContext, ReactNode, useContext, useState } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react'
 
-export type TabView = 'grocery' | 'pharmacy' | 'recipes'
+export type TabView = 'grocery' | 'pharmacy' | 'recipes' | 'purpose'
 
 interface TabViewContextType {
   activeTab: TabView
   setActiveTab: (tab: TabView) => void
+  // Which purpose list is selected when activeTab === 'purpose'
+  activePurposeListId: string | null
+  selectPurposeList: (id: string) => void
 }
 
 const TabViewContext = createContext<TabViewContextType | undefined>(undefined)
@@ -16,10 +19,25 @@ interface TabViewProviderProps {
 }
 
 export function TabViewProvider({ children }: TabViewProviderProps) {
-  const [activeTab, setActiveTab] = useState<TabView>('grocery')
+  const [activeTab, setActiveTabState] = useState<TabView>('grocery')
+  const [activePurposeListId, setActivePurposeListId] = useState<string | null>(null)
+
+  // Selecting any fixed tab clears the active purpose list selection.
+  const setActiveTab = useCallback((tab: TabView) => {
+    setActiveTabState(tab)
+    if (tab !== 'purpose') {
+      setActivePurposeListId(null)
+    }
+  }, [])
+
+  // Switch to a specific purpose list tab.
+  const selectPurposeList = useCallback((id: string) => {
+    setActivePurposeListId(id)
+    setActiveTabState('purpose')
+  }, [])
 
   return (
-    <TabViewContext.Provider value={{ activeTab, setActiveTab }}>
+    <TabViewContext.Provider value={{ activeTab, setActiveTab, activePurposeListId, selectPurposeList }}>
       {children}
     </TabViewContext.Provider>
   )
@@ -31,4 +49,4 @@ export function useTabView() {
     throw new Error('useTabView must be used within a TabViewProvider')
   }
   return context
-} 
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,29 @@
+rules_version = '2';
+
+// Firestore security rules for the Stocked shared grocery list app.
+//
+// IMPORTANT: The "purpose-based lists" feature stores its data in a new
+// top-level `purposeLists` field on each list document. If your existing
+// production rules restrict which keys a write may contain (e.g. a
+// `hasOnly(['categories', 'createdAt', 'updatedAt'])` check), then creating
+// a list document works the first time but every later update that touches
+// `purposeLists` (adding a category, creating a second list, etc.) is
+// rejected with permission-denied. Add `purposeLists` to the allowed keys —
+// as shown below — and redeploy the rules for the feature to persist.
+//
+// Deploy with the Firebase CLI:  firebase deploy --only firestore:rules
+// or paste the contents into Firebase console → Firestore → Rules.
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /lists/{listId} {
+      // Shared lists are accessed by URL without authentication.
+      allow read: if true;
+
+      // Only allow the known document shape, now including `purposeLists`.
+      allow write: if request.resource.data.keys().hasOnly(
+        ['categories', 'purposeLists', 'createdAt', 'updatedAt']
+      );
+    }
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import { Category, initialCategories } from '@/types/categories'
+import { PurposeList } from '@/types/purpose-list'
 import { FirebaseError } from 'firebase/app'
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore'
 import { toast } from 'sonner'
@@ -8,8 +9,54 @@ import { db } from './firebase'
 
 interface ListData {
   categories: Category[]
+  purposeLists?: PurposeList[]
   createdAt: string
   updatedAt: string
+}
+
+// Ensure categories/items have the exact required structure before persisting.
+// Strips unknown fields and normalizes optional/numeric fields to safe defaults.
+function sanitizeCategories(categories: Category[]): Category[] {
+  return categories.map(category => ({
+    id: category.id,
+    emoji: category.emoji,
+    name: category.name,
+    items: category.items.map(item => ({
+      id: item.id,
+      name: item.name,
+      purchased: item.purchased,
+      comment: item.comment || '',
+      photo: item.photo || null,
+      lastPurchaseAt: item.lastPurchaseAt || null,
+      expectedGapDays:
+        typeof item.expectedGapDays === 'number' && Number.isFinite(item.expectedGapDays)
+          ? item.expectedGapDays
+          : null,
+      gapVariance:
+        typeof item.gapVariance === 'number' && Number.isFinite(item.gapVariance)
+          ? item.gapVariance
+          : null,
+      decayedCount:
+        typeof item.decayedCount === 'number' && Number.isFinite(item.decayedCount)
+          ? item.decayedCount
+          : 0,
+      purchaseCount:
+        typeof item.purchaseCount === 'number' && Number.isFinite(item.purchaseCount)
+          ? item.purchaseCount
+          : 0,
+      snoozeUntil: item.snoozeUntil || null
+    }))
+  }))
+}
+
+function sanitizePurposeLists(purposeLists: PurposeList[]): PurposeList[] {
+  return purposeLists.map(list => ({
+    id: list.id,
+    name: list.name,
+    emoji: list.emoji,
+    createdAt: list.createdAt,
+    categories: sanitizeCategories(list.categories ?? [])
+  }))
 }
 
 export async function createNewList(listId: string, categories: Category[]) {
@@ -51,6 +98,7 @@ export async function getList(listId: string): Promise<ListData | null> {
     // Return initial categories for new lists
     return {
       categories: initialCategories,
+      purposeLists: [],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     }
@@ -65,43 +113,20 @@ export async function getList(listId: string): Promise<ListData | null> {
   }
 }
 
-export async function updateList(listId: string, categories: Category[]) {
+export async function updateList(listId: string, categories: Category[], purposeLists: PurposeList[] = []) {
   try {
-    // Check if the list has any items
-    const hasItems = categories.some(category => category.items.length > 0)
-    if (!hasItems) return
+    // Persist when grocery/pharmacy has items, OR when there is at least one
+    // (named) purpose list. This lets a freshly-created, still-empty purpose
+    // list survive a refresh while still avoiding empty grocery-only documents.
+    const groceryHasItems = categories.some(category => category.items.length > 0)
+    const hasNamedPurposeList = purposeLists.some(list => list.name.trim().length > 0)
+    if (!groceryHasItems && !hasNamedPurposeList) return
 
-    // Ensure categories have the exact required structure
-    const sanitizedCategories = categories.map(category => ({
-      id: category.id,
-      emoji: category.emoji,
-      name: category.name,
-      items: category.items.map(item => ({
-        id: item.id,
-        name: item.name,
-        purchased: item.purchased,
-        comment: item.comment || '',
-        photo: item.photo || null,
-        lastPurchaseAt: item.lastPurchaseAt || null,
-        expectedGapDays:
-          typeof item.expectedGapDays === 'number' && Number.isFinite(item.expectedGapDays)
-            ? item.expectedGapDays
-            : null,
-        gapVariance:
-          typeof item.gapVariance === 'number' && Number.isFinite(item.gapVariance)
-            ? item.gapVariance
-            : null,
-        decayedCount:
-          typeof item.decayedCount === 'number' && Number.isFinite(item.decayedCount)
-            ? item.decayedCount
-            : 0,
-        purchaseCount:
-          typeof item.purchaseCount === 'number' && Number.isFinite(item.purchaseCount)
-            ? item.purchaseCount
-            : 0,
-        snoozeUntil: item.snoozeUntil || null
-      }))
-    }))
+    // Ensure categories/purpose lists have the exact required structure.
+    // NOTE: setDoc rewrites the whole document, so purposeLists MUST be written
+    // in every branch or it would be deleted on the next grocery write.
+    const sanitizedCategories = sanitizeCategories(categories)
+    const sanitizedPurposeLists = sanitizePurposeLists(purposeLists)
 
     const listRef = doc(db, 'lists', listId)
     const listSnap = await getDoc(listRef)
@@ -113,6 +138,7 @@ export async function updateList(listId: string, categories: Category[]) {
       // Create new list with all required fields
       await setDoc(listRef, {
         categories: sanitizedCategories,
+        purposeLists: sanitizedPurposeLists,
         createdAt: timestamp,
         updatedAt: timestamp
       })
@@ -120,6 +146,7 @@ export async function updateList(listId: string, categories: Category[]) {
       // Update existing list with only allowed fields
       await setDoc(listRef, {
         categories: sanitizedCategories,
+        purposeLists: sanitizedPurposeLists,
         updatedAt: timestamp
       })
     }
@@ -146,23 +173,31 @@ export function subscribeToList(
     snapshot => {
       if (snapshot.exists()) {
         const data = snapshot.data() as ListData
-        const normalizedCategories = data.categories?.map(category => ({
-          ...category,
-          items:
-            category.items?.map(item => ({
-              ...item,
-              comment: item.comment || '',
-              photo: item.photo || null
-            })) ?? []
-        })) ?? []
+        const normalizeCategories = (categories: Category[] | undefined) =>
+          categories?.map(category => ({
+            ...category,
+            items:
+              category.items?.map(item => ({
+                ...item,
+                comment: item.comment || '',
+                photo: item.photo || null
+              })) ?? []
+          })) ?? []
+
+        const normalizedPurposeLists = (data.purposeLists ?? []).map(list => ({
+          ...list,
+          categories: normalizeCategories(list.categories)
+        }))
 
         onData({
           ...data,
-          categories: normalizedCategories
+          categories: normalizeCategories(data.categories),
+          purposeLists: normalizedPurposeLists
         })
       } else {
         onData({
           categories: initialCategories,
+          purposeLists: [],
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString()
         })

--- a/tests/components/NameEmojiModal.test.tsx
+++ b/tests/components/NameEmojiModal.test.tsx
@@ -8,7 +8,7 @@ describe('NameEmojiModal', () => {
     vi.clearAllMocks()
   })
 
-  it('submits the typed name and selected emoji', async () => {
+  it('submits the typed name with the default emoji', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
 
@@ -16,37 +16,16 @@ describe('NameEmojiModal', () => {
       <NameEmojiModal
         title="רשימה חדשה"
         submitLabel="צור רשימה"
-        emojiPalette={['🎉', '🧳']}
+        initialEmoji="🧳"
         onSubmit={onSubmit}
         onClose={vi.fn()}
       />
     )
 
     await user.type(screen.getByPlaceholderText('שם'), 'טיול לאיטליה')
-    await user.click(screen.getByRole('button', { name: '🧳' }))
     await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
 
     expect(onSubmit).toHaveBeenCalledWith('טיול לאיטליה', '🧳')
-  })
-
-  it('defaults the emoji to the first palette entry', async () => {
-    const user = userEvent.setup()
-    const onSubmit = vi.fn()
-
-    render(
-      <NameEmojiModal
-        title="קטגוריה חדשה"
-        submitLabel="הוסף קטגוריה"
-        emojiPalette={['📦', '👕']}
-        onSubmit={onSubmit}
-        onClose={vi.fn()}
-      />
-    )
-
-    await user.type(screen.getByPlaceholderText('שם'), 'ביגוד')
-    await user.click(screen.getByRole('button', { name: 'הוסף קטגוריה' }))
-
-    expect(onSubmit).toHaveBeenCalledWith('ביגוד', '📦')
   })
 
   it('does not submit when the name is empty', async () => {
@@ -64,6 +43,19 @@ describe('NameEmojiModal', () => {
 
     await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('exposes an emoji picker trigger', () => {
+    render(
+      <NameEmojiModal
+        title="קטגוריה חדשה"
+        submitLabel="הוסף קטגוריה"
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText("בחירת אימוג'י")).toBeInTheDocument()
   })
 
   it('shows a delete action only in edit mode', () => {

--- a/tests/components/NameEmojiModal.test.tsx
+++ b/tests/components/NameEmojiModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import NameEmojiModal from '@/components/NameEmojiModal'
+
+describe('NameEmojiModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('submits the typed name and selected emoji', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <NameEmojiModal
+        title="רשימה חדשה"
+        submitLabel="צור רשימה"
+        emojiPalette={['🎉', '🧳']}
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('שם'), 'טיול לאיטליה')
+    await user.click(screen.getByRole('button', { name: '🧳' }))
+    await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('טיול לאיטליה', '🧳')
+  })
+
+  it('defaults the emoji to the first palette entry', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <NameEmojiModal
+        title="קטגוריה חדשה"
+        submitLabel="הוסף קטגוריה"
+        emojiPalette={['📦', '👕']}
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('שם'), 'ביגוד')
+    await user.click(screen.getByRole('button', { name: 'הוסף קטגוריה' }))
+
+    expect(onSubmit).toHaveBeenCalledWith('ביגוד', '📦')
+  })
+
+  it('does not submit when the name is empty', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+
+    render(
+      <NameEmojiModal
+        title="רשימה חדשה"
+        submitLabel="צור רשימה"
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows a delete action only in edit mode', () => {
+    const onDelete = vi.fn()
+    const { rerender } = render(
+      <NameEmojiModal
+        title="עריכת רשימה"
+        submitLabel="שמור"
+        initialName="חופשה"
+        initialEmoji="🏖️"
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />
+    )
+
+    expect(screen.getByTitle('מחיקה')).toBeInTheDocument()
+
+    rerender(
+      <NameEmojiModal
+        title="רשימה חדשה"
+        submitLabel="צור רשימה"
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTitle('מחיקה')).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/PurposeLists.test.tsx
+++ b/tests/components/PurposeLists.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HomeScreen from '@/components/HomeScreen'
+import { SettingsProvider } from '@/contexts/SettingsContext'
+import { TabViewProvider } from '@/contexts/TabViewContext'
+import { subscribeToList, updateList } from '@/lib/db'
+
+const renderWithProvider = (component: React.ReactElement) =>
+  render(<SettingsProvider><TabViewProvider>{component}</TabViewProvider></SettingsProvider>)
+
+// Faithful Firestore simulation: the subscription re-emits server state after
+// every write, exactly like onSnapshot does in the real app.
+function wireFirestoreSim() {
+  let server: any = { categories: [], purposeLists: [] }
+  let emit: ((data: any) => void) | null = null
+
+  vi.mocked(subscribeToList).mockImplementation((listId, onData) => {
+    emit = onData
+    onData(JSON.parse(JSON.stringify(server)))
+    return () => {}
+  })
+
+  vi.mocked(updateList).mockImplementation(async (listId, categories, purposeLists) => {
+    server = { categories, purposeLists: purposeLists ?? [] }
+    // mimic onSnapshot firing after the write commits
+    emit?.(JSON.parse(JSON.stringify(server)))
+  })
+
+  return { getServer: () => server }
+}
+
+describe('Purpose lists (end-to-end with faithful subscription)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.setItem('stocked-feature-flags', JSON.stringify({ enablePurposeLists: true }))
+  })
+
+  it('creates a list, a category, and a second list', async () => {
+    const sim = wireFirestoreSim()
+    const user = userEvent.setup()
+    renderWithProvider(<HomeScreen />)
+
+    // Create first list
+    await waitFor(() => expect(screen.getByTitle('רשימה חדשה')).toBeInTheDocument())
+    await user.click(screen.getByTitle('רשימה חדשה'))
+    await waitFor(() => expect(screen.getByPlaceholderText(/שם הרשימה/)).toBeInTheDocument())
+    await user.type(screen.getByPlaceholderText(/שם הרשימה/), 'טיול')
+    await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'הוסף קטגוריה' })).toBeInTheDocument())
+
+    // Add a category
+    await user.click(screen.getByRole('button', { name: 'הוסף קטגוריה' }))
+    await waitFor(() => expect(screen.getByPlaceholderText('שם הקטגוריה')).toBeInTheDocument())
+    await user.type(screen.getByPlaceholderText('שם הקטגוריה'), 'ביגוד')
+    const addCatButtons = screen.getAllByRole('button', { name: 'הוסף קטגוריה' })
+    await user.click(addCatButtons[addCatButtons.length - 1])
+
+    await waitFor(() => expect(screen.getByText('ביגוד')).toBeInTheDocument())
+    expect(sim.getServer().purposeLists[0].categories).toHaveLength(1)
+
+    // Create a second list
+    await user.click(screen.getByTitle('רשימה חדשה'))
+    await waitFor(() => expect(screen.getByPlaceholderText(/שם הרשימה/)).toBeInTheDocument())
+    await user.type(screen.getByPlaceholderText(/שם הרשימה/), 'מסיבה')
+    await user.click(screen.getByRole('button', { name: 'צור רשימה' }))
+
+    await waitFor(() => expect(sim.getServer().purposeLists).toHaveLength(2))
+    expect(screen.getAllByText('מסיבה').length).toBeGreaterThan(0)
+  })
+})

--- a/tests/lib/db.test.ts
+++ b/tests/lib/db.test.ts
@@ -16,7 +16,7 @@ describe('Database Operations', () => {
 
       const unsubscribe = subscribeToList('test-list', onData, onError)
 
-      expect(onData).toHaveBeenCalledWith({ categories: [] })
+      expect(onData).toHaveBeenCalledWith({ categories: [], purposeLists: [] })
       expect(onError).not.toHaveBeenCalled()
 
       unsubscribe()
@@ -60,6 +60,21 @@ describe('Database Operations', () => {
       await updateList('test-list', categories)
 
       expect(updateList).toHaveBeenCalledTimes(2)
+    })
+
+    it('accepts purpose lists as a third argument', async () => {
+      const purposeLists = [
+        {
+          id: 'trip-1',
+          name: 'טיול לאיטליה',
+          emoji: '🧳',
+          categories: [],
+          createdAt: new Date().toISOString(),
+        },
+      ]
+
+      await expect(updateList('test-list', [], purposeLists)).resolves.toBeUndefined()
+      expect(updateList).toHaveBeenCalledWith('test-list', [], purposeLists)
     })
   })
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -27,10 +27,11 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/lib/db', () => ({
   subscribeToList: vi.fn((listId, onData, onError) => {
     // Return mock data immediately
-    onData({ categories: [] })
+    onData({ categories: [], purposeLists: [] })
     return () => {} // unsubscribe function
   }),
   updateList: vi.fn(() => Promise.resolve()),
+  createNewList: vi.fn((listId: string) => Promise.resolve(listId)),
 }))
 
 // Mock OpenRouter API

--- a/types/purpose-list.ts
+++ b/types/purpose-list.ts
@@ -1,0 +1,11 @@
+import { Category } from './categories'
+
+// A purpose-based list (e.g. an event, occasion, or travel packing) that lives
+// alongside the grocery/pharmacy categories inside the same shared list document.
+export interface PurposeList {
+  id: string
+  name: string
+  emoji: string
+  categories: Category[]
+  createdAt: string
+}


### PR DESCRIPTION
Introduce purpose-based lists (events, occasions, travel packing) that live
as dynamic tabs inside the existing shared list, alongside grocery/pharmacy.
Gated behind a new "רשימות ייעודיות" experimental flag.

- Data model: new PurposeList type stored in a top-level `purposeLists` array
  on the list document, isolated from the grocery/pharmacy categories.
- Persistence: updateList now threads purposeLists through every write and
  writes them in both setDoc branches; the empty-list guard only blocks
  creating brand-new empty docs, so named purpose lists persist and can be
  emptied/deleted. getList and subscribeToList read/normalize purposeLists.
- Tabs: TabView gains a 'purpose' mode plus activePurposeListId selection;
  CompactHeader renders a tab per list + a create button.
- HomeScreen: a single commitCategories helper routes reads/writes to the
  active purpose list or the main categories. Repeat suggestions and AI
  categorization are suppressed in purpose mode (manual categories only).
- UI: create/rename/delete lists and add categories via a reusable
  NameEmojiModal; CategoryList renders empty purpose categories.
- Tests: cover NameEmojiModal and updateList's purposeLists argument.

https://claude.ai/code/session_01N6rjkqZaWQYeCctNdzMxLP