### PR TITLE
Add focused in-store Shopping Mode

### DIFF
--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -112,10 +112,12 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
             />
           </div>
 
-          {/* Progress ring */}
-          <div className="flex-shrink-0">
-            <CircularProgress percentage={progressPercentage} />
-          </div>
+          {/* Progress ring — hidden when Shopping Mode owns the progress view */}
+          {!flags.enableShoppingMode && (
+            <div className="flex-shrink-0">
+              <CircularProgress percentage={progressPercentage} />
+            </div>
+          )}
 
           {/* Tab Pills */}
           <div className="flex bg-gray-100 rounded-full p-1">
@@ -159,14 +161,16 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
           {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
             {flags.enableShoppingMode && activeTab !== 'recipes' && (
-              <button
+              <motion.button
                 onClick={onEnterShoppingMode}
                 disabled={totalItems === 0}
-                className="p-2 text-[#FFB74D] hover:text-white hover:bg-[#FFB74D] rounded-full transition-all duration-200 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-[#FFB74D]"
+                whileTap={{ scale: 0.92 }}
+                whileHover={{ scale: 1.06 }}
+                className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-[#FFB74D] to-[#FFA726] text-white rounded-full shadow-sm shadow-orange-300/40 hover:shadow-md hover:shadow-orange-300/50 transition-shadow duration-200 disabled:opacity-40 disabled:shadow-none"
                 title="מצב קנייה"
               >
                 <Store className="w-5 h-5" />
-              </button>
+              </motion.button>
             )}
             <button
               onClick={onOpenSettings}

--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -158,7 +158,7 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
 
           {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
-            {activeTab !== 'recipes' && (
+            {flags.enableShoppingMode && activeTab !== 'recipes' && (
               <button
                 onClick={onEnterShoppingMode}
                 disabled={totalItems === 0}

--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useSettings } from '@/contexts/SettingsContext'
 import { useTabView } from '@/contexts/TabViewContext'
-import { ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Search, X } from 'lucide-react'
+import { ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Search, X, Store } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
@@ -13,6 +13,7 @@ interface CompactHeaderProps {
   searchQuery: string
   onSearchChange: (query: string) => void
   onOpenSettings: () => void
+  onEnterShoppingMode: () => void
 }
 
 function CircularProgress({ percentage }: { percentage: number }) {
@@ -65,7 +66,7 @@ function CircularProgress({ percentage }: { percentage: number }) {
   )
 }
 
-export default function CompactHeader({ uncheckedItems, totalItems, searchQuery, onSearchChange, onOpenSettings }: CompactHeaderProps) {
+export default function CompactHeader({ uncheckedItems, totalItems, searchQuery, onSearchChange, onOpenSettings, onEnterShoppingMode }: CompactHeaderProps) {
   const params = useParams()
   const listId = params?.listId as string
   const { activeTab, setActiveTab } = useTabView()
@@ -155,8 +156,18 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
             )}
           </div>
 
-          {/* Settings & Share buttons */}
+          {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
+            {activeTab !== 'recipes' && (
+              <button
+                onClick={onEnterShoppingMode}
+                disabled={totalItems === 0}
+                className="p-2 text-[#FFB74D] hover:text-white hover:bg-[#FFB74D] rounded-full transition-all duration-200 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-[#FFB74D]"
+                title="מצב קנייה"
+              >
+                <Store className="w-5 h-5" />
+              </button>
+            )}
             <button
               onClick={onOpenSettings}
               className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-all duration-200"

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -1055,7 +1055,7 @@ export default function HomeScreen() {
       </AnimatePresence>
 
       <AnimatePresence>
-        {isShoppingMode && (
+        {isShoppingMode && flags.enableShoppingMode && (
           <ShoppingMode
             categories={categories}
             onToggleItem={handleToggleItem}

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -20,6 +20,7 @@ import RepeatSuggestions from './RepeatSuggestions'
 
 const SettingsPanel = dynamic(() => import('./SettingsPanel'))
 const RecipesTab = dynamic(() => import('./RecipesTab'))
+const ShoppingMode = dynamic(() => import('./ShoppingMode'))
 
 // Lazy load modal components to reduce initial bundle size
 const AddItemForm = dynamic(() => import('./AddItemForm'), {
@@ -50,6 +51,7 @@ export default function HomeScreen() {
   const [pendingScrollItemId, setPendingScrollItemId] = useState<number | null>(null)
   const [pendingAddCount, setPendingAddCount] = useState(0)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isShoppingMode, setIsShoppingMode] = useState(false)
   const { activeTab } = useTabView()
   const { flags } = useSettings()
 
@@ -787,6 +789,7 @@ export default function HomeScreen() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         onOpenSettings={() => setIsSettingsOpen(true)}
+        onEnterShoppingMode={() => setIsShoppingMode(true)}
       />
       <AnimatePresence>
         {isSettingsOpen && (
@@ -1048,6 +1051,16 @@ export default function HomeScreen() {
               <Plus className="h-6 w-6" />
             </button>
           </motion.div>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {isShoppingMode && (
+          <ShoppingMode
+            categories={categories}
+            onToggleItem={handleToggleItem}
+            onExit={() => setIsShoppingMode(false)}
+          />
         )}
       </AnimatePresence>
     </div>

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useSettings } from '@/contexts/SettingsContext'
 import { motion } from 'framer-motion'
-import { ChefHat, Star, X } from 'lucide-react'
+import { ChefHat, Star, Store, X } from 'lucide-react'
 
 interface SettingsPanelProps {
   onClose: () => void
@@ -85,6 +85,14 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           description="סמן פריטים שנקנים הכי הרבה ומיין לפיהם בכל קטגוריה"
           enabled={flags.enableMostPurchased}
           onToggle={(v) => setFlag('enableMostPurchased', v)}
+        />
+
+        <FeatureToggle
+          icon={<Store className="h-5 w-5" />}
+          title="מצב קנייה"
+          description="תצוגה ממוקדת לסופר: היכנס לכל קטגוריה וסמן פריטים בקלות"
+          enabled={flags.enableShoppingMode}
+          onToggle={(v) => setFlag('enableShoppingMode', v)}
         />
       </div>
     </motion.div>

--- a/components/ShoppingMode.tsx
+++ b/components/ShoppingMode.tsx
@@ -5,7 +5,7 @@ import { Category } from '@/types/categories'
 import { Item } from '@/types/item'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowRight, Check, PartyPopper, X } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 interface ShoppingModeProps {
   categories: Category[]
@@ -57,6 +57,8 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
     ? relevantCategories.find(c => c.id === selectedCategoryId) ?? null
     : null
 
+  const handleBack = useCallback(() => setSelectedCategoryId(null), [])
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -106,7 +108,7 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
                 key={`detail-${selectedCategory.id}`}
                 category={selectedCategory}
                 onToggleItem={onToggleItem}
-                onBack={() => setSelectedCategoryId(null)}
+                onBack={handleBack}
               />
             ) : (
               <CategoryGrid
@@ -215,24 +217,28 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
   // Default to revealing completed items only when nothing is left to buy
   const [showCompleted, setShowCompleted] = useState(remainingItems.length === 0)
 
-  // Celebrate when the category gets cleared while viewing it
-  const justFinished = remainingItems.length === 0
+  // Celebrate and auto-return to the grid when the LAST item is checked off
+  // while viewing the category (but not when opening an already-finished one).
+  const prevRemainingRef = useRef(remainingItems.length)
   useEffect(() => {
-    if (!justFinished) return
-    let cancelled = false
-    import('canvas-confetti').then(module => {
-      if (cancelled) return
-      module.default({
-        particleCount: 80,
-        spread: 70,
-        origin: { y: 0.6 },
-        colors: ['#FFB74D', '#FFA726', '#FF9800', '#FB8C00', '#F57C00'],
+    const prev = prevRemainingRef.current
+    const curr = remainingItems.length
+    prevRemainingRef.current = curr
+
+    if (prev > 0 && curr === 0) {
+      import('canvas-confetti').then(module => {
+        module.default({
+          particleCount: 80,
+          spread: 70,
+          origin: { y: 0.6 },
+          colors: ['#FFB74D', '#FFA726', '#FF9800', '#FB8C00', '#F57C00'],
+        })
       })
-    })
-    return () => {
-      cancelled = true
+
+      const timer = setTimeout(onBack, 1100)
+      return () => clearTimeout(timer)
     }
-  }, [justFinished])
+  }, [remainingItems.length, onBack])
 
   return (
     <motion.div

--- a/components/ShoppingMode.tsx
+++ b/components/ShoppingMode.tsx
@@ -79,17 +79,17 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
         })
       })
 
-      const timer = setTimeout(() => setSelectedCategoryId(null), 550)
+      const timer = setTimeout(() => setSelectedCategoryId(null), 400)
       return () => clearTimeout(timer)
     }
   }, [selectedRemaining])
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 28 }}
+      initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 28 }}
-      transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+      exit={{ opacity: 0, y: 20 }}
+      transition={{ duration: 0.16, ease: 'easeOut' }}
       className="fixed inset-0 z-50 bg-[#FDF6ED] flex flex-col text-right pt-safe"
       dir="rtl"
     >
@@ -119,7 +119,7 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
               className="h-full bg-[#FFB74D] rounded-full"
               initial={false}
               animate={{ width: `${progress}%` }}
-              transition={{ duration: 0.4, ease: 'easeOut' }}
+              transition={{ duration: 0.25, ease: 'easeOut' }}
             />
           </div>
         </div>
@@ -174,10 +174,10 @@ function CategoryGrid({ categories, onSelect, allDone }: CategoryGridProps) {
 
   return (
     <motion.div
-      initial={{ opacity: 0, x: 20 }}
+      initial={{ opacity: 0, x: 12 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: 20 }}
-      transition={{ duration: 0.2 }}
+      exit={{ opacity: 0, x: 12 }}
+      transition={{ duration: 0.12, ease: 'easeOut' }}
     >
       {allDone && (
         <motion.div
@@ -245,10 +245,10 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
 
   return (
     <motion.div
-      initial={{ opacity: 0, x: -20 }}
+      initial={{ opacity: 0, x: -12 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -20 }}
-      transition={{ duration: 0.2 }}
+      exit={{ opacity: 0, x: -12 }}
+      transition={{ duration: 0.12, ease: 'easeOut' }}
     >
       {/* Back + title */}
       <button
@@ -272,7 +272,7 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
       </div>
 
       {/* Remaining items */}
-      {remainingItems.length > 0 ? (
+      {remainingItems.length > 0 && (
         <div className="bg-white rounded-2xl border border-black/5 shadow-sm overflow-hidden">
           <ul className="divide-y divide-black/5 list-none">
             <AnimatePresence initial={false}>
@@ -286,23 +286,6 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
             </AnimatePresence>
           </ul>
         </div>
-      ) : (
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          className="bg-white rounded-2xl border border-black/5 shadow-sm p-8 text-center"
-        >
-          <div className="text-4xl mb-3">✅</div>
-          <h3 className="text-base font-semibold text-black/80 mb-1">סיימת את {category.name}</h3>
-          <p className="text-sm text-black/60 mb-4">כל הפריטים סומנו כנקנו</p>
-          <button
-            onClick={onBack}
-            className="inline-flex items-center gap-1.5 bg-[#FFB74D] hover:bg-[#FFA726] text-white text-sm font-medium rounded-full px-4 py-2 transition-colors"
-          >
-            <ArrowRight className="w-4 h-4" />
-            חזרה לקטגוריות
-          </button>
-        </motion.div>
       )}
 
       {/* Completed items (collapsible) so mistakes can be undone */}
@@ -323,7 +306,7 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
+                transition={{ duration: 0.13, ease: 'easeOut' }}
                 className="overflow-hidden"
               >
                 <div className="bg-white/60 rounded-2xl border border-black/5 overflow-hidden mt-2">
@@ -358,7 +341,7 @@ function ShoppingRow({ item, onToggle }: ShoppingRowProps) {
       initial={{ opacity: 0, height: 0 }}
       animate={{ opacity: 1, height: 'auto' }}
       exit={{ opacity: 0, height: 0 }}
-      transition={{ duration: 0.2 }}
+      transition={{ duration: 0.13, ease: 'easeOut' }}
       className="list-none"
     >
       <button

--- a/components/ShoppingMode.tsx
+++ b/components/ShoppingMode.tsx
@@ -59,6 +59,31 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
 
   const handleBack = useCallback(() => setSelectedCategoryId(null), [])
 
+  // Celebrate and auto-return to the grid when the LAST item of the open
+  // category is checked off. Tracked here in the parent (which never
+  // remounts) so the transition is detected reliably. A -1 sentinel means
+  // no category is open, so opening an already-finished category never fires.
+  const selectedRemaining = selectedCategory ? remainingCount(selectedCategory) : -1
+  const prevRemainingRef = useRef(-1)
+  useEffect(() => {
+    const prev = prevRemainingRef.current
+    prevRemainingRef.current = selectedRemaining
+
+    if (prev > 0 && selectedRemaining === 0) {
+      import('canvas-confetti').then(module => {
+        module.default({
+          particleCount: 80,
+          spread: 70,
+          origin: { y: 0.6 },
+          colors: ['#FFB74D', '#FFA726', '#FF9800', '#FB8C00', '#F57C00'],
+        })
+      })
+
+      const timer = setTimeout(() => setSelectedCategoryId(null), 550)
+      return () => clearTimeout(timer)
+    }
+  }, [selectedRemaining])
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -216,29 +241,6 @@ function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps)
   const completedItems = category.items.filter(item => item.purchased)
   // Default to revealing completed items only when nothing is left to buy
   const [showCompleted, setShowCompleted] = useState(remainingItems.length === 0)
-
-  // Celebrate and auto-return to the grid when the LAST item is checked off
-  // while viewing the category (but not when opening an already-finished one).
-  const prevRemainingRef = useRef(remainingItems.length)
-  useEffect(() => {
-    const prev = prevRemainingRef.current
-    const curr = remainingItems.length
-    prevRemainingRef.current = curr
-
-    if (prev > 0 && curr === 0) {
-      import('canvas-confetti').then(module => {
-        module.default({
-          particleCount: 80,
-          spread: 70,
-          origin: { y: 0.6 },
-          colors: ['#FFB74D', '#FFA726', '#FF9800', '#FB8C00', '#F57C00'],
-        })
-      })
-
-      const timer = setTimeout(onBack, 1100)
-      return () => clearTimeout(timer)
-    }
-  }, [remainingItems.length, onBack])
 
   return (
     <motion.div

--- a/components/ShoppingMode.tsx
+++ b/components/ShoppingMode.tsx
@@ -86,9 +86,10 @@ export default function ShoppingMode({ categories, onToggleItem, onExit }: Shopp
 
   return (
     <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
+      initial={{ opacity: 0, y: 28 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 28 }}
+      transition={{ type: 'spring', damping: 30, stiffness: 300 }}
       className="fixed inset-0 z-50 bg-[#FDF6ED] flex flex-col text-right pt-safe"
       dir="rtl"
     >

--- a/components/ShoppingMode.tsx
+++ b/components/ShoppingMode.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+import { useTabView } from '@/contexts/TabViewContext'
+import { Category } from '@/types/categories'
+import { Item } from '@/types/item'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ArrowRight, Check, PartyPopper, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+interface ShoppingModeProps {
+  categories: Category[]
+  onToggleItem: (categoryId: number, itemId: number) => void
+  onExit: () => void
+}
+
+function remainingCount(category: Category): number {
+  return category.items.filter(item => !item.purchased).length
+}
+
+// Active categories first, fully-completed ones dimmed at the bottom
+function sortForShopping(categories: Category[]): Category[] {
+  return [...categories].sort((a, b) => {
+    const aDone = remainingCount(a) === 0
+    const bDone = remainingCount(b) === 0
+    if (aDone === bDone) return 0
+    return aDone ? 1 : -1
+  })
+}
+
+export default function ShoppingMode({ categories, onToggleItem, onExit }: ShoppingModeProps) {
+  const { activeTab } = useTabView()
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null)
+
+  // Only the categories relevant to the current tab that actually have items
+  const relevantCategories = useMemo(() => {
+    return categories.filter(category => {
+      if (category.items.length === 0) return false
+      if (activeTab === 'pharmacy') return category.name === 'בית מרקחת'
+      return category.name !== 'בית מרקחת'
+    })
+  }, [categories, activeTab])
+
+  const sortedCategories = useMemo(() => sortForShopping(relevantCategories), [relevantCategories])
+
+  const totalItems = useMemo(
+    () => relevantCategories.reduce((sum, c) => sum + c.items.length, 0),
+    [relevantCategories]
+  )
+  const remainingItems = useMemo(
+    () => relevantCategories.reduce((sum, c) => sum + remainingCount(c), 0),
+    [relevantCategories]
+  )
+  const doneItems = totalItems - remainingItems
+  const progress = totalItems > 0 ? Math.round((doneItems / totalItems) * 100) : 0
+
+  const selectedCategory = selectedCategoryId
+    ? relevantCategories.find(c => c.id === selectedCategoryId) ?? null
+    : null
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 bg-[#FDF6ED] flex flex-col text-right pt-safe"
+      dir="rtl"
+    >
+      {/* Header */}
+      <div className="bg-white border-b border-black/5 shadow-sm">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-base font-bold text-black/80">מצב קנייה</h1>
+            <p className="text-xs text-black/50">
+              {remainingItems > 0
+                ? `נשארו ${remainingItems} פריטים לקנייה`
+                : 'סיימת את כל הרשימה 🎉'}
+            </p>
+          </div>
+          <button
+            onClick={onExit}
+            className="flex-shrink-0 flex items-center gap-1.5 text-sm text-black/60 hover:text-black/80 bg-gray-100 hover:bg-gray-200 rounded-full px-3 py-1.5 transition-colors"
+          >
+            <X className="w-4 h-4" />
+            <span>סיום</span>
+          </button>
+        </div>
+        {/* Overall progress bar */}
+        <div className="max-w-2xl mx-auto px-4 pb-3">
+          <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
+            <motion.div
+              className="h-full bg-[#FFB74D] rounded-full"
+              initial={false}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto p-4 pb-24">
+          <AnimatePresence mode="wait">
+            {selectedCategory ? (
+              <CategoryDetail
+                key={`detail-${selectedCategory.id}`}
+                category={selectedCategory}
+                onToggleItem={onToggleItem}
+                onBack={() => setSelectedCategoryId(null)}
+              />
+            ) : (
+              <CategoryGrid
+                key="grid"
+                categories={sortedCategories}
+                onSelect={setSelectedCategoryId}
+                allDone={totalItems > 0 && remainingItems === 0}
+              />
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+interface CategoryGridProps {
+  categories: Category[]
+  onSelect: (categoryId: number) => void
+  allDone: boolean
+}
+
+function CategoryGrid({ categories, onSelect, allDone }: CategoryGridProps) {
+  if (categories.length === 0) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-white rounded-2xl border border-black/5 shadow-sm p-10 text-center mt-6"
+      >
+        <div className="text-4xl mb-4">🛒</div>
+        <h3 className="text-lg font-semibold text-black/80 mb-2">אין פריטים לקנייה</h3>
+        <p className="text-sm text-black/60">הוסיפו פריטים לרשימה כדי להתחיל לקנות</p>
+      </motion.div>
+    )
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 20 }}
+      transition={{ duration: 0.2 }}
+    >
+      {allDone && (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="bg-gradient-to-r from-[#FFB74D] to-[#FFA726] text-white rounded-2xl p-5 mb-4 flex items-center gap-3 shadow-md shadow-orange-200/50"
+        >
+          <PartyPopper className="w-7 h-7 flex-shrink-0" />
+          <div>
+            <p className="font-bold">כל הכבוד, סיימת!</p>
+            <p className="text-sm text-white/90">כל הפריטים סומנו כנקנו</p>
+          </div>
+        </motion.div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        {categories.map(category => {
+          const remaining = remainingCount(category)
+          const isDone = remaining === 0
+          return (
+            <motion.button
+              key={category.id}
+              layout
+              onClick={() => onSelect(category.id)}
+              whileTap={{ scale: 0.97 }}
+              className={`relative flex flex-col items-center justify-center gap-2 rounded-2xl border shadow-sm p-5 min-h-[120px] transition-colors ${
+                isDone
+                  ? 'bg-gray-50 border-black/5 opacity-60'
+                  : 'bg-white border-black/5 hover:border-[#FFB74D]/40'
+              }`}
+            >
+              <span className="text-4xl">{category.emoji}</span>
+              <span className="text-sm font-semibold text-black/80 text-center leading-tight">
+                {category.name}
+              </span>
+              {isDone ? (
+                <span className="flex items-center gap-1 text-xs font-medium text-green-600">
+                  <Check className="w-3.5 h-3.5" />
+                  הושלם
+                </span>
+              ) : (
+                <span className="absolute top-2.5 left-2.5 min-w-[24px] h-6 px-1.5 flex items-center justify-center rounded-full bg-[#FFB74D] text-white text-xs font-bold">
+                  {remaining}
+                </span>
+              )}
+            </motion.button>
+          )
+        })}
+      </div>
+    </motion.div>
+  )
+}
+
+interface CategoryDetailProps {
+  category: Category
+  onToggleItem: (categoryId: number, itemId: number) => void
+  onBack: () => void
+}
+
+function CategoryDetail({ category, onToggleItem, onBack }: CategoryDetailProps) {
+  const remainingItems = category.items.filter(item => !item.purchased)
+  const completedItems = category.items.filter(item => item.purchased)
+  // Default to revealing completed items only when nothing is left to buy
+  const [showCompleted, setShowCompleted] = useState(remainingItems.length === 0)
+
+  // Celebrate when the category gets cleared while viewing it
+  const justFinished = remainingItems.length === 0
+  useEffect(() => {
+    if (!justFinished) return
+    let cancelled = false
+    import('canvas-confetti').then(module => {
+      if (cancelled) return
+      module.default({
+        particleCount: 80,
+        spread: 70,
+        origin: { y: 0.6 },
+        colors: ['#FFB74D', '#FFA726', '#FF9800', '#FB8C00', '#F57C00'],
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [justFinished])
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -20 }}
+      transition={{ duration: 0.2 }}
+    >
+      {/* Back + title */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1.5 text-sm font-medium text-black/60 hover:text-black/80 mb-4"
+      >
+        <ArrowRight className="w-4 h-4" />
+        <span>כל הקטגוריות</span>
+      </button>
+
+      <div className="flex items-center gap-3 mb-4">
+        <span className="text-3xl">{category.emoji}</span>
+        <div>
+          <h2 className="text-lg font-bold text-black/80">{category.name}</h2>
+          <p className="text-xs text-black/50">
+            {remainingItems.length > 0
+              ? `${remainingItems.length} פריטים לקנייה`
+              : 'הקטגוריה הושלמה'}
+          </p>
+        </div>
+      </div>
+
+      {/* Remaining items */}
+      {remainingItems.length > 0 ? (
+        <div className="bg-white rounded-2xl border border-black/5 shadow-sm overflow-hidden">
+          <ul className="divide-y divide-black/5 list-none">
+            <AnimatePresence initial={false}>
+              {remainingItems.map(item => (
+                <ShoppingRow
+                  key={item.id}
+                  item={item}
+                  onToggle={() => onToggleItem(category.id, item.id)}
+                />
+              ))}
+            </AnimatePresence>
+          </ul>
+        </div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="bg-white rounded-2xl border border-black/5 shadow-sm p-8 text-center"
+        >
+          <div className="text-4xl mb-3">✅</div>
+          <h3 className="text-base font-semibold text-black/80 mb-1">סיימת את {category.name}</h3>
+          <p className="text-sm text-black/60 mb-4">כל הפריטים סומנו כנקנו</p>
+          <button
+            onClick={onBack}
+            className="inline-flex items-center gap-1.5 bg-[#FFB74D] hover:bg-[#FFA726] text-white text-sm font-medium rounded-full px-4 py-2 transition-colors"
+          >
+            <ArrowRight className="w-4 h-4" />
+            חזרה לקטגוריות
+          </button>
+        </motion.div>
+      )}
+
+      {/* Completed items (collapsible) so mistakes can be undone */}
+      {completedItems.length > 0 && (
+        <div className="mt-4">
+          <button
+            onClick={() => setShowCompleted(prev => !prev)}
+            className="flex items-center gap-1.5 text-sm text-black/50 hover:text-black/70 transition-colors"
+          >
+            <Check className="w-4 h-4 text-green-500" />
+            <span>{completedItems.length} פריטים שכבר נקנו</span>
+            <span className="text-xs text-black/40">{showCompleted ? '(הסתר)' : '(הצג)'}</span>
+          </button>
+
+          <AnimatePresence initial={false}>
+            {showCompleted && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="overflow-hidden"
+              >
+                <div className="bg-white/60 rounded-2xl border border-black/5 overflow-hidden mt-2">
+                  <ul className="divide-y divide-black/5 list-none">
+                    {completedItems.map(item => (
+                      <ShoppingRow
+                        key={item.id}
+                        item={item}
+                        onToggle={() => onToggleItem(category.id, item.id)}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
+    </motion.div>
+  )
+}
+
+interface ShoppingRowProps {
+  item: Item
+  onToggle: () => void
+}
+
+function ShoppingRow({ item, onToggle }: ShoppingRowProps) {
+  return (
+    <motion.li
+      layout
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={{ opacity: 0, height: 0 }}
+      transition={{ duration: 0.2 }}
+      className="list-none"
+    >
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 px-4 py-4 text-right active:bg-black/5 transition-colors"
+      >
+        <span
+          className={`flex-shrink-0 w-7 h-7 rounded-lg border-2 flex items-center justify-center transition-colors ${
+            item.purchased
+              ? 'bg-[#FFB74D] border-[#FFB74D] text-white'
+              : 'border-gray-300 text-transparent'
+          }`}
+        >
+          <Check className="w-5 h-5" strokeWidth={3} />
+        </span>
+        <span className="flex-1 min-w-0 flex items-baseline gap-2">
+          <span
+            className={`text-base truncate ${
+              item.purchased ? 'line-through text-black/40' : 'text-black/80 font-medium'
+            }`}
+          >
+            {item.name}
+          </span>
+          {item.comment && (
+            <span className="text-sm text-black/40 truncate">({item.comment})</span>
+          )}
+        </span>
+      </button>
+    </motion.li>
+  )
+}

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -5,11 +5,13 @@ import { createContext, ReactNode, useCallback, useContext, useEffect, useState 
 interface FeatureFlags {
   enableRecipes: boolean
   enableMostPurchased: boolean
+  enableShoppingMode: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   enableRecipes: false,
   enableMostPurchased: false,
+  enableShoppingMode: false,
 }
 
 interface SettingsContextType {

--- a/tests/components/ShoppingMode.test.tsx
+++ b/tests/components/ShoppingMode.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ShoppingMode from '@/components/ShoppingMode'
+import { Category } from '@/types/categories'
+import { Item } from '@/types/item'
+import { SettingsProvider } from '@/contexts/SettingsContext'
+import { TabViewProvider } from '@/contexts/TabViewContext'
+
+// Confetti is a fire-and-forget side effect; stub it so the dynamic import
+// resolves without touching the canvas in jsdom.
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }))
+
+// Strip framer-motion's animation lifecycle so view swaps (AnimatePresence
+// mode="wait") and enter/exit transitions resolve synchronously in tests.
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  const MOTION_PROPS = new Set([
+    'initial', 'animate', 'exit', 'transition', 'layout', 'variants',
+    'whileTap', 'whileHover', 'whileInView', 'whileFocus', 'whileDrag',
+    'drag', 'dragConstraints', 'dragElastic', 'onDragEnd', 'onDragStart',
+  ])
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) =>
+        React.forwardRef(function MotionMock(props: any, ref: any) {
+          const clean: Record<string, any> = {}
+          for (const key in props) {
+            if (!MOTION_PROPS.has(key)) clean[key] = props[key]
+          }
+          return React.createElement(tag, { ...clean, ref })
+        }),
+    }
+  )
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useMotionValue: (value: number) => ({ get: () => value, set: () => {} }),
+  }
+})
+
+function makeItem(id: number, name: string, purchased = false): Item {
+  return {
+    id,
+    name,
+    purchased,
+    comment: '',
+    photo: null,
+    lastPurchaseAt: null,
+    expectedGapDays: null,
+    gapVariance: null,
+    decayedCount: 0,
+    purchaseCount: 0,
+    snoozeUntil: null,
+  }
+}
+
+const baseCategories: Category[] = [
+  {
+    id: 1,
+    name: 'ירקות',
+    emoji: '🥬',
+    items: [makeItem(11, 'מלפפון', false), makeItem(12, 'עגבניה', true)],
+  },
+  {
+    id: 2,
+    name: 'פירות',
+    emoji: '🍎',
+    items: [makeItem(21, 'תפוח', false)],
+  },
+  {
+    id: 99,
+    name: 'בית מרקחת',
+    emoji: '💊',
+    items: [makeItem(31, 'אקמול', false)],
+  },
+]
+
+function renderShoppingMode(
+  categories: Category[],
+  overrides: Partial<React.ComponentProps<typeof ShoppingMode>> = {}
+) {
+  const props = {
+    categories,
+    onToggleItem: vi.fn(),
+    onExit: vi.fn(),
+    ...overrides,
+  }
+  const utils = render(
+    <SettingsProvider>
+      <TabViewProvider>
+        <ShoppingMode {...props} />
+      </TabViewProvider>
+    </SettingsProvider>
+  )
+  return { ...utils, props }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ShoppingMode - category grid', () => {
+  it('renders a card per grocery category with the remaining count', () => {
+    renderShoppingMode(baseCategories)
+
+    expect(screen.getByText('ירקות')).toBeInTheDocument()
+    expect(screen.getByText('פירות')).toBeInTheDocument()
+    // ירקות and פירות each have 1 unpurchased item -> two "1" badges
+    expect(screen.getAllByText('1')).toHaveLength(2)
+  })
+
+  it('excludes the pharmacy category while on the grocery tab', () => {
+    renderShoppingMode(baseCategories)
+
+    expect(screen.queryByText('בית מרקחת')).not.toBeInTheDocument()
+    expect(screen.queryByText('אקמול')).not.toBeInTheDocument()
+  })
+
+  it('shows the total remaining count in the header', () => {
+    // grocery remaining = ירקות(1) + פירות(1) = 2
+    renderShoppingMode(baseCategories)
+    expect(screen.getByText('נשארו 2 פריטים לקנייה')).toBeInTheDocument()
+  })
+
+  it('calls onExit when the close button is clicked', () => {
+    const { props } = renderShoppingMode(baseCategories)
+    fireEvent.click(screen.getByText('סיום'))
+    expect(props.onExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the celebration banner when everything is purchased', () => {
+    const allDone: Category[] = [
+      { id: 1, name: 'ירקות', emoji: '🥬', items: [makeItem(11, 'מלפפון', true)] },
+    ]
+    renderShoppingMode(allDone)
+    expect(screen.getByText('כל הכבוד, סיימת!')).toBeInTheDocument()
+  })
+
+  it('renders an empty state when there is nothing to shop', () => {
+    renderShoppingMode([])
+    expect(screen.getByText('אין פריטים לקנייה')).toBeInTheDocument()
+  })
+})
+
+describe('ShoppingMode - category detail', () => {
+  it('drilling into a category shows unpurchased items and hides purchased ones', () => {
+    renderShoppingMode(baseCategories)
+
+    fireEvent.click(screen.getByText('ירקות'))
+
+    // Unpurchased item is visible
+    expect(screen.getByText('מלפפון')).toBeInTheDocument()
+    // Purchased item is hidden from the aisle view by default
+    expect(screen.queryByText('עגבניה')).not.toBeInTheDocument()
+  })
+
+  it('checking an item calls onToggleItem with the category and item ids', () => {
+    const { props } = renderShoppingMode(baseCategories)
+
+    fireEvent.click(screen.getByText('ירקות'))
+    fireEvent.click(screen.getByText('מלפפון'))
+
+    expect(props.onToggleItem).toHaveBeenCalledWith(1, 11)
+  })
+
+  it('reveals already-bought items when the completed section is expanded', () => {
+    renderShoppingMode(baseCategories)
+
+    fireEvent.click(screen.getByText('ירקות'))
+    // Toggle to reveal completed items
+    fireEvent.click(screen.getByText('1 פריטים שכבר נקנו'))
+
+    expect(screen.getByText('עגבניה')).toBeInTheDocument()
+  })
+
+  it('navigates back to the grid via the back button', () => {
+    renderShoppingMode(baseCategories)
+
+    fireEvent.click(screen.getByText('ירקות'))
+    expect(screen.getByText('כל הקטגוריות')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('כל הקטגוריות'))
+    // Back on the grid: both category cards visible again, no back button
+    expect(screen.queryByText('כל הקטגוריות')).not.toBeInTheDocument()
+    expect(screen.getByText('נשארו 2 פריטים לקנייה')).toBeInTheDocument()
+  })
+})
+
+describe('ShoppingMode - auto return on completion', () => {
+  it('returns to the grid shortly after the last item in a category is checked', async () => {
+    const { rerender } = renderShoppingMode(baseCategories)
+
+    // Drill into פירות (single unpurchased item)
+    fireEvent.click(screen.getByText('פירות'))
+    expect(screen.getByText('כל הקטגוריות')).toBeInTheDocument()
+
+    // Simulate the parent marking that item purchased
+    const cleared: Category[] = baseCategories.map(c =>
+      c.id === 2 ? { ...c, items: [makeItem(21, 'תפוח', true)] } : c
+    )
+
+    rerender(
+      <SettingsProvider>
+        <TabViewProvider>
+          <ShoppingMode categories={cleared} onToggleItem={vi.fn()} onExit={vi.fn()} />
+        </TabViewProvider>
+      </SettingsProvider>
+    )
+
+    // Auto-returns to the grid after the short celebration delay
+    await waitFor(
+      () => expect(screen.queryByText('כל הקטגוריות')).not.toBeInTheDocument(),
+      { timeout: 1500 }
+    )
+  })
+})


### PR DESCRIPTION
Adds a full-screen "מצב קנייה" (Shopping Mode) for use while at the
supermarket, entered via a new Store-icon button in the header.

- Category grid → drill in: a clean grid of category cards (emoji +
  remaining count) that you tap to open a focused view of that
  category's items.
- Minimal rows: large tap-to-check targets with item name + comment
  only, no edit/delete/swipe clutter.
- Checked items are hidden from the aisle view; a collapsible
  "already bought" section lets you reveal and undo them.
- Per-category and overall progress, confetti on completion, and a
  celebratory finished state. Respects the active grocery/pharmacy tab
  and stays in Firebase sync via the existing toggle handler.