### PR TITLE
Add Shopping Insights experiment and a seeded demo/sandbox list

### DIFF
--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useSettings } from '@/contexts/SettingsContext'
 import { useTabView } from '@/contexts/TabViewContext'
-import { ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Search, X, Store } from 'lucide-react'
+import { BarChart3, ChefHat, Settings, Share2, ShoppingCart, Pill, Check, Search, X, Store } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
@@ -156,11 +156,24 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
                 <span className="hidden sm:inline">מתכונים</span>
               </button>
             )}
+            {flags.enableInsights && (
+              <button
+                onClick={() => setActiveTab('insights')}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+                  activeTab === 'insights'
+                    ? 'bg-[#FFB74D] text-white shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                <BarChart3 className="w-4 h-4" />
+                <span className="hidden sm:inline">תובנות</span>
+              </button>
+            )}
           </div>
 
           {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
-            {flags.enableShoppingMode && activeTab !== 'recipes' && (
+            {flags.enableShoppingMode && (activeTab === 'grocery' || activeTab === 'pharmacy') && (
               <motion.button
                 onClick={onEnterShoppingMode}
                 disabled={totalItems === 0}

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -3,6 +3,7 @@
 import { useSettings } from '@/contexts/SettingsContext'
 import { useTabView } from '@/contexts/TabViewContext'
 import { subscribeToList, updateList } from '@/lib/db'
+import { buildDemoCategories, isDemoList } from '@/lib/demo'
 import { OpenRouter } from '@/lib/openrouter'
 import { computeRepeatSuggestions, updateItemPurchaseStats } from '@/lib/repeat-suggester'
 import { Category, initialCategories } from '@/types/categories'
@@ -21,6 +22,7 @@ import RepeatSuggestions from './RepeatSuggestions'
 const SettingsPanel = dynamic(() => import('./SettingsPanel'))
 const RecipesTab = dynamic(() => import('./RecipesTab'))
 const ShoppingMode = dynamic(() => import('./ShoppingMode'))
+const InsightsTab = dynamic(() => import('./InsightsTab'))
 
 // Lazy load modal components to reduce initial bundle size
 const AddItemForm = dynamic(() => import('./AddItemForm'), {
@@ -54,6 +56,10 @@ export default function HomeScreen() {
   const [isShoppingMode, setIsShoppingMode] = useState(false)
   const { activeTab } = useTabView()
   const { flags } = useSettings()
+
+  // The grocery/pharmacy list views share the search, suggestions, category
+  // list and add-item FAB. The recipes and insights tabs replace all of that.
+  const isListTab = activeTab === 'grocery' || activeTab === 'pharmacy'
 
   // Filter items based on search query
   const getSearchResults = () => {
@@ -696,6 +702,13 @@ export default function HomeScreen() {
     )
 
   useEffect(() => {
+    // Demo/sandbox list: load ephemeral seeded data and skip Firebase entirely.
+    if (isDemoList(listId)) {
+      setCategories(buildDemoCategories())
+      setIsLoading(false)
+      return
+    }
+
     setIsLoading(true)
 
     const unsubscribe = subscribeToList(
@@ -827,8 +840,13 @@ export default function HomeScreen() {
           />
         )}
 
+        {/* Insights Tab */}
+        {activeTab === 'insights' && flags.enableInsights && (
+          <InsightsTab categories={categories} />
+        )}
+
         {/* Search Results */}
-        {activeTab !== 'recipes' && isSearchMode && (
+        {isListTab && isSearchMode && (
           <div className="space-y-4 mb-6">
             {searchResults.length > 0 && !hasExactMatch && (
               <motion.button
@@ -922,7 +940,7 @@ export default function HomeScreen() {
           </div>
         )}
 
-        {activeTab !== 'recipes' && !isSearchMode && repeatSuggestions.length > 0 && (
+        {isListTab && !isSearchMode && repeatSuggestions.length > 0 && (
           <div className="mb-6">
             <RepeatSuggestions
               suggestions={repeatSuggestions}
@@ -932,8 +950,8 @@ export default function HomeScreen() {
           </div>
         )}
 
-        {/* Category List - Only show when not in search mode and not on recipes tab */}
-        {activeTab !== 'recipes' && !isSearchMode && (
+        {/* Category List - only on the grocery/pharmacy list views, not while searching */}
+        {isListTab && !isSearchMode && (
           <CategoryList
             categories={categories.filter(category => category.items.length > 0)}
             onToggleItem={handleToggleItem}
@@ -1037,7 +1055,7 @@ export default function HomeScreen() {
       </AnimatePresence>
 
       <AnimatePresence>
-        {!isAddFormOpen && activeTab !== 'recipes' && (
+        {!isAddFormOpen && isListTab && (
           <motion.div
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -819,7 +819,7 @@ export default function HomeScreen() {
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: -20 }}
               transition={{ type: 'spring', damping: 25, stiffness: 350 }}
-              className="fixed inset-x-4 top-[12vh] z-50 max-w-md mx-auto"
+              className="fixed inset-x-4 top-[10vh] bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 mx-auto flex max-w-md items-start"
             >
               <SettingsPanel onClose={() => setIsSettingsOpen(false)} />
             </motion.div>

--- a/components/InsightsTab.tsx
+++ b/components/InsightsTab.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { computeInsights, type CategoryInsight, type ItemInsight } from '@/lib/insights'
+import { Category } from '@/types/categories'
+import { motion } from 'framer-motion'
+import { BarChart3, Repeat, ShoppingBag, TrendingUp } from 'lucide-react'
+import { useMemo } from 'react'
+
+interface InsightsTabProps {
+  categories: Category[]
+}
+
+const formatInterval = (days: number | null) => {
+  if (days === null || !Number.isFinite(days) || days <= 0) return ''
+  if (days < 1.5) return 'כל יום'
+  if (days < 14) return `כל ${Math.round(days)} ימים`
+  if (days < 60) return `כל ${Math.round(days / 7)} שבועות`
+  if (days < 365) return `כל ${Math.round(days / 30)} חודשים`
+  return `כל ${Math.round(days / 365)} שנים`
+}
+
+function StatCard({ icon, value, label }: { icon: React.ReactNode; value: number; label: string }) {
+  return (
+    <div className="flex-1 rounded-2xl border border-black/5 bg-white p-3 text-center shadow-sm">
+      <div className="mb-1 flex justify-center text-[#FFB74D]">{icon}</div>
+      <div className="text-2xl font-bold text-black/80">{value}</div>
+      <div className="text-[11px] leading-tight text-black/50">{label}</div>
+    </div>
+  )
+}
+
+function BarRow({
+  label,
+  emoji,
+  value,
+  max,
+  caption,
+}: {
+  label: string
+  emoji?: string
+  value: number
+  max: number
+  caption?: string
+}) {
+  const widthPercent = max > 0 ? Math.max((value / max) * 100, 6) : 0
+
+  return (
+    <div className="flex items-center gap-3">
+      {emoji && (
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-neutral-50 text-base">
+          {emoji}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-baseline justify-between gap-2">
+          <span className="truncate text-sm font-medium text-neutral-800">{label}</span>
+          <span className="shrink-0 text-xs font-semibold text-neutral-500">
+            {caption ?? value}
+          </span>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-neutral-100">
+          <motion.div
+            initial={{ width: 0 }}
+            animate={{ width: `${widthPercent}%` }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            className="h-full rounded-full bg-gradient-to-l from-[#FFB74D] to-[#FFA726]"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SectionCard({
+  title,
+  icon,
+  children,
+}: {
+  title: string
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-2xl border border-black/5 bg-white p-4 shadow-sm">
+      <div className="mb-4 flex items-center gap-2">
+        <span className="text-[#FFB74D]">{icon}</span>
+        <h3 className="text-sm font-bold text-black/80">{title}</h3>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function InsightsTab({ categories }: InsightsTabProps) {
+  const insights = useMemo(() => computeInsights(categories), [categories])
+
+  if (insights.totalPurchases === 0) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        dir="rtl"
+        className="flex flex-col items-center justify-center rounded-2xl border border-black/5 bg-white px-6 py-16 text-center shadow-sm"
+      >
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50">
+          <BarChart3 className="h-8 w-8 text-[#FFB74D]" />
+        </div>
+        <h3 className="text-base font-bold text-black/80">עדיין אין תובנות</h3>
+        <p className="mt-1.5 max-w-xs text-sm leading-relaxed text-black/50">
+          ככל שתסמנו פריטים שנקנו, נלמד את הרגלי הקנייה שלכם ונציג כאן סטטיסטיקות מעניינות.
+        </p>
+      </motion.div>
+    )
+  }
+
+  const maxItemCount = insights.topItems[0]?.purchaseCount ?? 0
+  const maxCategoryCount = insights.categoryBreakdown[0]?.purchaseCount ?? 0
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      dir="rtl"
+      className="space-y-4"
+    >
+      {/* Summary stats */}
+      <div className="flex gap-3">
+        <StatCard
+          icon={<ShoppingBag className="h-5 w-5" />}
+          value={insights.totalPurchases}
+          label="סך הכל קניות"
+        />
+        <StatCard
+          icon={<TrendingUp className="h-5 w-5" />}
+          value={insights.trackedItems}
+          label="פריטים במעקב"
+        />
+        <StatCard
+          icon={<Repeat className="h-5 w-5" />}
+          value={insights.activeStaples}
+          label="מצרכים קבועים"
+        />
+      </div>
+
+      {/* Top purchased items */}
+      {insights.topItems.length > 0 && (
+        <SectionCard title="הפריטים הנקנים ביותר" icon={<ShoppingBag className="h-4 w-4" />}>
+          <div className="space-y-3">
+            {insights.topItems.map((item: ItemInsight) => (
+              <BarRow
+                key={`${item.categoryId}-${item.name}`}
+                label={item.name}
+                emoji={item.categoryEmoji}
+                value={item.purchaseCount}
+                max={maxItemCount}
+                caption={`${item.purchaseCount} פעמים`}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {/* Purchases by category */}
+      {insights.categoryBreakdown.length > 0 && (
+        <SectionCard title="קניות לפי קטגוריה" icon={<BarChart3 className="h-4 w-4" />}>
+          <div className="space-y-3">
+            {insights.categoryBreakdown.map((cat: CategoryInsight) => (
+              <BarRow
+                key={cat.categoryId}
+                label={cat.name}
+                emoji={cat.emoji}
+                value={cat.purchaseCount}
+                max={maxCategoryCount}
+                caption={`${cat.purchaseCount}`}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {/* Most regular staples */}
+      {insights.mostRegular.length > 0 && (
+        <SectionCard title="המצרכים הכי קבועים" icon={<Repeat className="h-4 w-4" />}>
+          <div className="space-y-2">
+            {insights.mostRegular.map((item: ItemInsight) => (
+              <div
+                key={`${item.categoryId}-${item.name}`}
+                className="flex items-center gap-3 rounded-xl bg-neutral-50 p-2.5"
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white text-base shadow-sm">
+                  {item.categoryEmoji}
+                </div>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-neutral-800">
+                  {item.name}
+                </span>
+                <span className="shrink-0 text-xs font-semibold text-[#FFA726]">
+                  {formatInterval(item.expectedGapDays)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      <p className="pb-2 text-center text-[11px] text-neutral-400">
+        מבוסס על היסטוריית הקניות שלך
+      </p>
+    </motion.div>
+  )
+}

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -58,7 +58,7 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
       transition={{ type: 'spring', damping: 25, stiffness: 350 }}
-      className="bg-white rounded-2xl shadow-2xl border border-black/5 overflow-hidden flex flex-col max-h-[80vh]"
+      className="bg-white rounded-2xl shadow-2xl border border-black/5 overflow-hidden flex flex-col w-full max-h-full"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-black/5 flex-shrink-0">

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useSettings } from '@/contexts/SettingsContext'
+import { DEMO_LIST_ID, isDemoList } from '@/lib/demo'
 import { motion } from 'framer-motion'
-import { ChefHat, Star, Store, X } from 'lucide-react'
+import { BarChart3, ChefHat, FlaskConical, Star, Store, X } from 'lucide-react'
+import { useParams } from 'next/navigation'
 
 interface SettingsPanelProps {
   onClose: () => void
@@ -47,6 +49,8 @@ function FeatureToggle({ icon, title, description, enabled, onToggle }: FeatureT
 
 export default function SettingsPanel({ onClose }: SettingsPanelProps) {
   const { flags, setFlag } = useSettings()
+  const params = useParams()
+  const inDemo = isDemoList(params?.listId as string | undefined)
 
   return (
     <motion.div
@@ -94,6 +98,34 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           enabled={flags.enableShoppingMode}
           onToggle={(v) => setFlag('enableShoppingMode', v)}
         />
+
+        <FeatureToggle
+          icon={<BarChart3 className="h-5 w-5" />}
+          title="תובנות"
+          description="סטטיסטיקות על הרגלי הקנייה: הפריטים הנקנים ביותר, קניות לפי קטגוריה ומצרכים קבועים"
+          enabled={flags.enableInsights}
+          onToggle={(v) => setFlag('enableInsights', v)}
+        />
+      </div>
+
+      {/* Demo / sandbox entry */}
+      <div className="border-t border-black/5 p-4">
+        <a
+          href={`/share/${DEMO_LIST_ID}`}
+          className="flex items-start gap-3 rounded-xl border border-dashed border-[#FFB74D]/50 bg-amber-50/50 p-4 transition-colors hover:bg-amber-50"
+        >
+          <div className="mt-0.5 flex-shrink-0 text-[#FFB74D]">
+            <FlaskConical className="h-5 w-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-semibold text-black/80">
+              {inDemo ? 'אתה במצב הדגמה' : 'מצב הדגמה (Demo)'}
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-black/50">
+              נסה את כל התכונות עם נתוני דמה עשירים — בלי להשפיע על הרשימה האמיתית שלך. כל שינוי מתאפס בריענון.
+            </p>
+          </div>
+        </a>
       </div>
     </motion.div>
   )

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -58,10 +58,10 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
       transition={{ type: 'spring', damping: 25, stiffness: 350 }}
-      className="bg-white rounded-2xl shadow-2xl border border-black/5 overflow-hidden"
+      className="bg-white rounded-2xl shadow-2xl border border-black/5 overflow-hidden flex flex-col max-h-[80vh]"
     >
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-black/5">
+      <div className="flex items-center justify-between p-4 border-b border-black/5 flex-shrink-0">
         <h2 className="text-base font-bold text-black/80">הגדרות</h2>
         <button
           onClick={onClose}
@@ -71,6 +71,8 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
         </button>
       </div>
 
+      {/* Scrollable body */}
+      <div className="overflow-y-auto overscroll-contain">
       {/* Feature Flags */}
       <div className="p-4 space-y-3">
         <p className="text-xs text-black/40 font-medium mb-2">תכונות ניסיוניות</p>
@@ -126,6 +128,7 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
             </p>
           </div>
         </a>
+      </div>
       </div>
     </motion.div>
   )

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -1,17 +1,30 @@
 'use client'
 
+import { isDemoList } from '@/lib/demo'
+import { useParams } from 'next/navigation'
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react'
 
 interface FeatureFlags {
   enableRecipes: boolean
   enableMostPurchased: boolean
   enableShoppingMode: boolean
+  enableInsights: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   enableRecipes: false,
   enableMostPurchased: false,
   enableShoppingMode: false,
+  enableInsights: false,
+}
+
+// In the demo/sandbox list every experimental feature is on by default so a
+// tester sees everything at once (toggles still work for checking the gating).
+const ALL_FLAGS_ENABLED: FeatureFlags = {
+  enableRecipes: true,
+  enableMostPurchased: true,
+  enableShoppingMode: true,
+  enableInsights: true,
 }
 
 interface SettingsContextType {
@@ -42,19 +55,22 @@ interface SettingsProviderProps {
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps) {
+  const params = useParams()
+  const isDemo = isDemoList(params?.listId as string | undefined)
   const [flags, setFlags] = useState<FeatureFlags>(DEFAULT_FLAGS)
   const [isHydrated, setIsHydrated] = useState(false)
 
   useEffect(() => {
-    setFlags(loadFlags())
+    setFlags(isDemo ? ALL_FLAGS_ENABLED : loadFlags())
     setIsHydrated(true)
-  }, [])
+  }, [isDemo])
 
   useEffect(() => {
-    if (isHydrated) {
+    // Never persist demo overrides onto the user's real settings.
+    if (isHydrated && !isDemo) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(flags))
     }
-  }, [flags, isHydrated])
+  }, [flags, isHydrated, isDemo])
 
   const setFlag = useCallback((key: keyof FeatureFlags, value: boolean) => {
     setFlags(prev => ({ ...prev, [key]: value }))

--- a/contexts/TabViewContext.tsx
+++ b/contexts/TabViewContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, ReactNode, useContext, useState } from 'react'
 
-export type TabView = 'grocery' | 'pharmacy' | 'recipes'
+export type TabView = 'grocery' | 'pharmacy' | 'recipes' | 'insights'
 
 interface TabViewContextType {
   activeTab: TabView

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,6 +2,7 @@ import { Category, initialCategories } from '@/types/categories'
 import { FirebaseError } from 'firebase/app'
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore'
 import { toast } from 'sonner'
+import { isDemoList } from './demo'
 import { db } from './firebase'
 
 
@@ -13,6 +14,8 @@ interface ListData {
 }
 
 export async function createNewList(listId: string, categories: Category[]) {
+  // Demo/sandbox lists are ephemeral and never written to Firebase.
+  if (isDemoList(listId)) return listId
   try {
     // Only create if there are items in any category
     const hasItems = categories.some(category => category.items.length > 0)
@@ -66,6 +69,8 @@ export async function getList(listId: string): Promise<ListData | null> {
 }
 
 export async function updateList(listId: string, categories: Category[]) {
+  // Demo/sandbox lists are ephemeral and never written to Firebase.
+  if (isDemoList(listId)) return
   try {
     // Check if the list has any items
     const hasItems = categories.some(category => category.items.length > 0)

--- a/lib/demo.ts
+++ b/lib/demo.ts
@@ -1,0 +1,131 @@
+import { Category } from '../types/categories'
+import { Item } from '../types/item'
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+// Reserved list ids that open an ephemeral, pre-seeded sandbox instead of a
+// real Firebase list. Anything you do here stays local and never persists, so
+// it's safe to play with experimental features without touching real data.
+const DEMO_LIST_IDS = new Set(['demo', 'sandbox', 'playground'])
+
+export const DEMO_LIST_ID = 'demo'
+
+export function isDemoList(listId: string | null | undefined): boolean {
+  if (!listId) return false
+  return DEMO_LIST_IDS.has(listId.trim().toLowerCase())
+}
+
+interface StapleSpec {
+  id: number
+  name: string
+  comment?: string
+  count: number
+  gapDays: number
+  lastAgoDays: number
+  variance: number
+}
+
+function makeStaple(spec: StapleSpec, now: Date): Item {
+  // Approximate the decayed count the EWMA tracker would have arrived at, so
+  // staple scores in the seeded data look realistic rather than maxed out.
+  const decayedCount = Math.min(spec.count, 6)
+
+  return {
+    id: spec.id,
+    name: spec.name,
+    purchased: true,
+    comment: spec.comment ?? '',
+    photo: null,
+    lastPurchaseAt: new Date(now.getTime() - spec.lastAgoDays * MS_PER_DAY).toISOString(),
+    expectedGapDays: spec.gapDays,
+    gapVariance: spec.variance,
+    decayedCount,
+    purchaseCount: spec.count,
+    snoozeUntil: null,
+  }
+}
+
+function makeFresh(id: number, name: string, comment = ''): Item {
+  return {
+    id,
+    name,
+    purchased: false,
+    comment,
+    photo: null,
+    lastPurchaseAt: null,
+    expectedGapDays: null,
+    gapVariance: null,
+    decayedCount: 0,
+    purchaseCount: 0,
+    snoozeUntil: null,
+  }
+}
+
+// A rich, realistic snapshot: a mix of items still to buy plus a deep purchase
+// history so repeat suggestions, "most purchased" and the insights view all
+// light up immediately. Timestamps are relative to `now` so the data never
+// goes stale.
+export function buildDemoCategories(now: Date = new Date()): Category[] {
+  return [
+    {
+      id: 1,
+      emoji: '🥬',
+      name: 'ירקות',
+      items: [
+        makeFresh(101, 'גזר'),
+        makeFresh(102, 'חסה', 'שלמה'),
+        makeStaple({ id: 103, name: 'עגבניות', count: 9, gapDays: 5, lastAgoDays: 6, variance: 2 }, now),
+        makeStaple({ id: 104, name: 'מלפפונים', count: 7, gapDays: 5, lastAgoDays: 3, variance: 3 }, now),
+        makeStaple({ id: 105, name: 'בצל', count: 4, gapDays: 14, lastAgoDays: 16, variance: 9 }, now),
+      ],
+    },
+    {
+      id: 2,
+      emoji: '🍎',
+      name: 'פירות',
+      items: [
+        makeFresh(201, 'אבטיח'),
+        makeStaple({ id: 202, name: 'בננות', count: 14, gapDays: 4, lastAgoDays: 5, variance: 1 }, now),
+        makeStaple({ id: 203, name: 'תפוחים', count: 8, gapDays: 7, lastAgoDays: 4, variance: 4 }, now),
+      ],
+    },
+    {
+      id: 3,
+      emoji: '🥛',
+      name: 'מוצרי חלב',
+      items: [
+        makeStaple({ id: 301, name: 'חלב', count: 22, gapDays: 3, lastAgoDays: 4, variance: 1 }, now),
+        makeStaple({ id: 302, name: 'ביצים', count: 16, gapDays: 7, lastAgoDays: 6, variance: 2 }, now),
+        makeStaple({ id: 303, name: 'גבינה צהובה', count: 9, gapDays: 7, lastAgoDays: 9, variance: 5 }, now),
+        makeStaple({ id: 304, name: 'יוגורט', count: 6, gapDays: 5, lastAgoDays: 2, variance: 4 }, now),
+      ],
+    },
+    {
+      id: 4,
+      emoji: '🍞',
+      name: 'מאפים',
+      items: [
+        makeFresh(401, 'פיתות'),
+        makeStaple({ id: 402, name: 'לחם', count: 19, gapDays: 3, lastAgoDays: 4, variance: 1 }, now),
+      ],
+    },
+    {
+      id: 5,
+      emoji: '🧼',
+      name: 'ניקיון',
+      items: [
+        makeStaple({ id: 501, name: 'נייר טואלט', count: 5, gapDays: 30, lastAgoDays: 33, variance: 20 }, now),
+        makeStaple({ id: 502, name: 'סבון כלים', count: 4, gapDays: 21, lastAgoDays: 10, variance: 12 }, now),
+      ],
+    },
+    {
+      id: 99,
+      emoji: '💊',
+      name: 'בית מרקחת',
+      items: [
+        makeFresh(901, 'ויטמין C'),
+        makeStaple({ id: 902, name: 'אקמול', count: 3, gapDays: 60, lastAgoDays: 25, variance: 30 }, now),
+      ],
+    },
+  ]
+}

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -1,0 +1,133 @@
+import { Category } from '../types/categories'
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+const MIN_PURCHASES_FOR_REGULARITY = 3
+const TOP_ITEMS_LIMIT = 8
+const REGULAR_ITEMS_LIMIT = 5
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+
+export interface ItemInsight {
+  name: string
+  categoryId: number
+  categoryName: string
+  categoryEmoji: string
+  purchaseCount: number
+  expectedGapDays: number | null
+  daysSinceLastPurchase: number | null
+}
+
+export interface CategoryInsight {
+  categoryId: number
+  name: string
+  emoji: string
+  purchaseCount: number
+  itemCount: number
+}
+
+export interface ShoppingInsights {
+  totalPurchases: number
+  trackedItems: number
+  activeStaples: number
+  topItems: ItemInsight[]
+  categoryBreakdown: CategoryInsight[]
+  mostRegular: ItemInsight[]
+}
+
+// Derives a read-only overview of shopping habits from the purchase stats the
+// EWMA tracker already records on each item. Pure and side-effect free so it
+// can be memoized in the UI and unit tested in isolation.
+export function computeInsights(
+  categories: Category[],
+  now: Date = new Date()
+): ShoppingInsights {
+  const allItems: ItemInsight[] = []
+  const categoryBreakdown: CategoryInsight[] = []
+  let totalPurchases = 0
+  let trackedItems = 0
+  let activeStaples = 0
+
+  categories.forEach(category => {
+    let categoryPurchases = 0
+    let categoryItemCount = 0
+
+    category.items.forEach(item => {
+      const purchaseCount = isFiniteNumber(item.purchaseCount) ? item.purchaseCount : 0
+      if (purchaseCount <= 0) return
+
+      totalPurchases += purchaseCount
+      trackedItems += 1
+      categoryPurchases += purchaseCount
+      categoryItemCount += 1
+      if (purchaseCount >= MIN_PURCHASES_FOR_REGULARITY) activeStaples += 1
+
+      const lastPurchaseAt = item.lastPurchaseAt ? new Date(item.lastPurchaseAt) : null
+      const daysSinceLastPurchase =
+        lastPurchaseAt && Number.isFinite(lastPurchaseAt.getTime())
+          ? Math.max((now.getTime() - lastPurchaseAt.getTime()) / MS_PER_DAY, 0)
+          : null
+
+      allItems.push({
+        name: item.name,
+        categoryId: category.id,
+        categoryName: category.name,
+        categoryEmoji: category.emoji,
+        purchaseCount,
+        expectedGapDays: isFiniteNumber(item.expectedGapDays) ? item.expectedGapDays : null,
+        daysSinceLastPurchase,
+      })
+    })
+
+    if (categoryPurchases > 0) {
+      categoryBreakdown.push({
+        categoryId: category.id,
+        name: category.name,
+        emoji: category.emoji,
+        purchaseCount: categoryPurchases,
+        itemCount: categoryItemCount,
+      })
+    }
+  })
+
+  const topItems = [...allItems]
+    .sort((a, b) => b.purchaseCount - a.purchaseCount)
+    .slice(0, TOP_ITEMS_LIMIT)
+
+  categoryBreakdown.sort((a, b) => b.purchaseCount - a.purchaseCount)
+
+  // "Most regular" = the staples we buy on the steadiest rhythm. Rank by the
+  // lowest gap variance among items with enough history and a known cadence.
+  const mostRegular = allItems
+    .filter(
+      item =>
+        item.purchaseCount >= MIN_PURCHASES_FOR_REGULARITY &&
+        item.expectedGapDays !== null
+    )
+    .map(item => {
+      const source = categories
+        .find(c => c.id === item.categoryId)
+        ?.items.find(i => i.name === item.name)
+      const variance = isFiniteNumber(source?.gapVariance) ? source!.gapVariance! : Infinity
+      return { item, variance }
+    })
+    .filter(entry => Number.isFinite(entry.variance))
+    .sort((a, b) => a.variance - b.variance)
+    .slice(0, REGULAR_ITEMS_LIMIT)
+    .map(entry => entry.item)
+
+  return {
+    totalPurchases,
+    trackedItems,
+    activeStaples,
+    topItems,
+    categoryBreakdown,
+    mostRegular,
+  }
+}
+
+export const INSIGHTS_CONSTANTS = {
+  MIN_PURCHASES_FOR_REGULARITY,
+  TOP_ITEMS_LIMIT,
+  REGULAR_ITEMS_LIMIT,
+}

--- a/tests/lib/demo.test.ts
+++ b/tests/lib/demo.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { buildDemoCategories, isDemoList, DEMO_LIST_ID } from '@/lib/demo'
+import { computeInsights } from '@/lib/insights'
+import { computeRepeatSuggestions } from '@/lib/repeat-suggester'
+
+describe('isDemoList', () => {
+  it('recognises the reserved sandbox ids (case-insensitive)', () => {
+    expect(isDemoList('demo')).toBe(true)
+    expect(isDemoList('DEMO')).toBe(true)
+    expect(isDemoList(' sandbox ')).toBe(true)
+    expect(isDemoList('playground')).toBe(true)
+    expect(isDemoList(DEMO_LIST_ID)).toBe(true)
+  })
+
+  it('treats real list ids and empty values as non-demo', () => {
+    expect(isDemoList('a1b2c3-real-uuid')).toBe(false)
+    expect(isDemoList('')).toBe(false)
+    expect(isDemoList(null)).toBe(false)
+    expect(isDemoList(undefined)).toBe(false)
+  })
+})
+
+describe('buildDemoCategories', () => {
+  it('seeds both items still to buy and a deep purchase history', () => {
+    const categories = buildDemoCategories()
+    const allItems = categories.flatMap(c => c.items)
+
+    expect(allItems.some(i => !i.purchased)).toBe(true)
+    expect(allItems.some(i => (i.purchaseCount ?? 0) >= 3 && i.lastPurchaseAt)).toBe(true)
+  })
+
+  it('produces data rich enough for repeat suggestions and insights', () => {
+    const categories = buildDemoCategories()
+
+    expect(computeRepeatSuggestions(categories).length).toBeGreaterThan(0)
+
+    const insights = computeInsights(categories)
+    expect(insights.totalPurchases).toBeGreaterThan(0)
+    expect(insights.topItems.length).toBeGreaterThan(0)
+    expect(insights.mostRegular.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/lib/insights.test.ts
+++ b/tests/lib/insights.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { computeInsights } from '@/lib/insights'
+import { Category } from '@/types/categories'
+import { Item } from '@/types/item'
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+const NOW = new Date('2026-06-06T12:00:00.000Z')
+
+function tracked(
+  id: number,
+  name: string,
+  opts: { count: number; gapDays?: number; lastAgoDays?: number; variance?: number }
+): Item {
+  return {
+    id,
+    name,
+    purchased: true,
+    comment: '',
+    photo: null,
+    lastPurchaseAt:
+      opts.lastAgoDays !== undefined
+        ? new Date(NOW.getTime() - opts.lastAgoDays * MS_PER_DAY).toISOString()
+        : null,
+    expectedGapDays: opts.gapDays ?? null,
+    gapVariance: opts.variance ?? null,
+    decayedCount: Math.min(opts.count, 6),
+    purchaseCount: opts.count,
+    snoozeUntil: null,
+  }
+}
+
+function fresh(id: number, name: string): Item {
+  return {
+    id,
+    name,
+    purchased: false,
+    comment: '',
+    photo: null,
+    lastPurchaseAt: null,
+    expectedGapDays: null,
+    gapVariance: null,
+    decayedCount: 0,
+    purchaseCount: 0,
+    snoozeUntil: null,
+  }
+}
+
+const categories: Category[] = [
+  {
+    id: 1,
+    name: 'מוצרי חלב',
+    emoji: '🥛',
+    items: [
+      tracked(11, 'חלב', { count: 20, gapDays: 3, lastAgoDays: 4, variance: 1 }),
+      tracked(12, 'ביצים', { count: 10, gapDays: 7, lastAgoDays: 6, variance: 2 }),
+      fresh(13, 'גבינה'),
+    ],
+  },
+  {
+    id: 2,
+    name: 'ירקות',
+    emoji: '🥬',
+    items: [
+      tracked(21, 'עגבניה', { count: 5, gapDays: 5, lastAgoDays: 6, variance: 8 }),
+      tracked(22, 'בצל', { count: 1, gapDays: 14, lastAgoDays: 2, variance: 1 }),
+    ],
+  },
+]
+
+describe('computeInsights', () => {
+  it('sums total purchases and counts only tracked items', () => {
+    const insights = computeInsights(categories, NOW)
+    // 20 + 10 + 5 + 1
+    expect(insights.totalPurchases).toBe(36)
+    // four items have purchaseCount > 0; the fresh "גבינה" is excluded
+    expect(insights.trackedItems).toBe(4)
+    // staples = purchaseCount >= 3 → חלב, ביצים, עגבניה
+    expect(insights.activeStaples).toBe(3)
+  })
+
+  it('ranks top items by purchase count', () => {
+    const insights = computeInsights(categories, NOW)
+    expect(insights.topItems.map(i => i.name)).toEqual(['חלב', 'ביצים', 'עגבניה', 'בצל'])
+    expect(insights.topItems[0].purchaseCount).toBe(20)
+  })
+
+  it('aggregates purchases per category, sorted descending', () => {
+    const insights = computeInsights(categories, NOW)
+    expect(insights.categoryBreakdown.map(c => [c.name, c.purchaseCount])).toEqual([
+      ['מוצרי חלב', 30],
+      ['ירקות', 6],
+    ])
+  })
+
+  it('orders most-regular staples by lowest variance and excludes thin history', () => {
+    const insights = computeInsights(categories, NOW)
+    // בצל has count 1 (< 3) so it is excluded despite low variance.
+    // Of the staples, ordering by variance asc: חלב(1), ביצים(2), עגבניה(8)
+    expect(insights.mostRegular.map(i => i.name)).toEqual(['חלב', 'ביצים', 'עגבניה'])
+  })
+
+  it('returns an empty overview when there is no purchase history', () => {
+    const empty: Category[] = [{ id: 1, name: 'ירקות', emoji: '🥬', items: [fresh(1, 'גזר')] }]
+    const insights = computeInsights(empty, NOW)
+    expect(insights.totalPurchases).toBe(0)
+    expect(insights.trackedItems).toBe(0)
+    expect(insights.topItems).toEqual([])
+    expect(insights.categoryBreakdown).toEqual([])
+    expect(insights.mostRegular).toEqual([])
+  })
+})


### PR DESCRIPTION
Shopping Insights (behind enableInsights flag): a new "תובנות" tab that
turns the purchase stats the EWMA tracker already records into a read-only
overview — total purchases, tracked items, most-purchased items, purchases
by category, and the most-regular staples. Pure computeInsights() in
lib/insights.ts so it's memoizable and unit tested.

Demo/sandbox list: opening /share/demo (or sandbox/playground) loads rich
ephemeral seeded data instead of a Firebase list, with every experimental
flag forced on, so new features can be exercised without creating a list or
touching real data. Writes are short-circuited at the db layer and reset on
reload. Reachable from a card in the settings panel.