### PR TITLE
Fix header tab shift and restyle demo mode entry

### DIFF
--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -173,24 +173,22 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
 
           {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
-            {flags.enableShoppingMode && (
-              <motion.button
-                onClick={onEnterShoppingMode}
-                disabled={totalItems === 0}
-                whileTap={{ scale: 0.92 }}
-                whileHover={{ scale: 1.06 }}
-                aria-hidden={!(activeTab === 'grocery' || activeTab === 'pharmacy')}
-                tabIndex={activeTab === 'grocery' || activeTab === 'pharmacy' ? 0 : -1}
-                className={`flex items-center justify-center w-10 h-10 bg-gradient-to-br from-[#FFB74D] to-[#FFA726] text-white rounded-full shadow-sm shadow-orange-300/40 hover:shadow-md hover:shadow-orange-300/50 transition-shadow duration-200 disabled:opacity-40 disabled:shadow-none ${
-                  activeTab === 'grocery' || activeTab === 'pharmacy'
-                    ? ''
-                    : 'invisible pointer-events-none'
-                }`}
-                title="מצב קנייה"
-              >
-                <Store className="w-5 h-5" />
-              </motion.button>
-            )}
+            {flags.enableShoppingMode && (() => {
+              const isShoppingRelevant = activeTab === 'grocery' || activeTab === 'pharmacy'
+              const isDisabled = !isShoppingRelevant || totalItems === 0
+              return (
+                <motion.button
+                  onClick={onEnterShoppingMode}
+                  disabled={isDisabled}
+                  whileTap={isDisabled ? undefined : { scale: 0.92 }}
+                  whileHover={isDisabled ? undefined : { scale: 1.06 }}
+                  className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-[#FFB74D] to-[#FFA726] text-white rounded-full shadow-sm shadow-orange-300/40 hover:shadow-md hover:shadow-orange-300/50 transition-shadow duration-200 disabled:opacity-40 disabled:shadow-none disabled:cursor-not-allowed"
+                  title="מצב קנייה"
+                >
+                  <Store className="w-5 h-5" />
+                </motion.button>
+              )
+            })()}
             <button
               onClick={onOpenSettings}
               className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-all duration-200"

--- a/components/CompactHeader.tsx
+++ b/components/CompactHeader.tsx
@@ -173,13 +173,19 @@ export default function CompactHeader({ uncheckedItems, totalItems, searchQuery,
 
           {/* Shopping mode, Settings & Share buttons */}
           <div className="flex items-center gap-1">
-            {flags.enableShoppingMode && (activeTab === 'grocery' || activeTab === 'pharmacy') && (
+            {flags.enableShoppingMode && (
               <motion.button
                 onClick={onEnterShoppingMode}
                 disabled={totalItems === 0}
                 whileTap={{ scale: 0.92 }}
                 whileHover={{ scale: 1.06 }}
-                className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-[#FFB74D] to-[#FFA726] text-white rounded-full shadow-sm shadow-orange-300/40 hover:shadow-md hover:shadow-orange-300/50 transition-shadow duration-200 disabled:opacity-40 disabled:shadow-none"
+                aria-hidden={!(activeTab === 'grocery' || activeTab === 'pharmacy')}
+                tabIndex={activeTab === 'grocery' || activeTab === 'pharmacy' ? 0 : -1}
+                className={`flex items-center justify-center w-10 h-10 bg-gradient-to-br from-[#FFB74D] to-[#FFA726] text-white rounded-full shadow-sm shadow-orange-300/40 hover:shadow-md hover:shadow-orange-300/50 transition-shadow duration-200 disabled:opacity-40 disabled:shadow-none ${
+                  activeTab === 'grocery' || activeTab === 'pharmacy'
+                    ? ''
+                    : 'invisible pointer-events-none'
+                }`}
                 title="מצב קנייה"
               >
                 <Store className="w-5 h-5" />

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -110,23 +110,20 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
         />
       </div>
 
-      {/* Demo / sandbox entry */}
-      <div className="border-t border-black/5 p-4">
+      {/* Demo / sandbox section */}
+      <div className="border-t border-black/5 p-4 space-y-3">
+        <p className="text-xs text-black/40 font-medium mb-2">מצב הדגמה</p>
+
+        <p className="text-xs leading-relaxed text-black/50">
+          נסה את כל התכונות עם נתוני דמה עשירים — בלי להשפיע על הרשימה האמיתית שלך. כל שינוי מתאפס בריענון.
+        </p>
+
         <a
           href={`/share/${DEMO_LIST_ID}`}
-          className="flex items-start gap-3 rounded-xl border border-dashed border-[#FFB74D]/50 bg-amber-50/50 p-4 transition-colors hover:bg-amber-50"
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-[#FFB74D] px-4 py-3 text-sm font-semibold text-white shadow-sm shadow-orange-300/40 transition-colors hover:bg-[#FFA726]"
         >
-          <div className="mt-0.5 flex-shrink-0 text-[#FFB74D]">
-            <FlaskConical className="h-5 w-5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-semibold text-black/80">
-              {inDemo ? 'אתה במצב הדגמה' : 'מצב הדגמה (Demo)'}
-            </h3>
-            <p className="mt-1 text-xs leading-relaxed text-black/50">
-              נסה את כל התכונות עם נתוני דמה עשירים — בלי להשפיע על הרשימה האמיתית שלך. כל שינוי מתאפס בריענון.
-            </p>
-          </div>
+          <FlaskConical className="h-4 w-4" />
+          <span>{inDemo ? 'אתה במצב הדגמה' : 'פתח מצב הדגמה'}</span>
         </a>
       </div>
       </div>


### PR DESCRIPTION
Follow-up polish to the Shopping Insights / demo-mode work merged in #44. This commit was pushed after #44 was merged, so it lands here on a fresh branch.

## Changes

**Header: stop the tab toggle from shifting**
The shopping-mode button was removed from the DOM on the recipes/insights tabs, so the header's `justify-between` redistributed and the tab pills jumped. Now, whenever Shopping Mode is enabled, the button always occupies its slot — it just becomes `invisible pointer-events-none` (and is dropped from tab order / hidden from screen readers) on non-list tabs. Same layout, no shift.

**Settings: restyle demo mode as its own section**
The demo entry no longer looks like an ambiguous dashed card. It's now its own labeled section ("מצב הדגמה") below the experiment toggles, with the explanation as plain text and a clear solid button ("פתח מצב הדגמה") so it reads as a tappable action.

https://claude.ai/code/session_01Mf9pfPg2p8hWoQuuCFcLa5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf9pfPg2p8hWoQuuCFcLa5)_